### PR TITLE
Added Custom Fully Qualified Key Paths

### DIFF
--- a/Sources/Vexil/Flag.swift
+++ b/Sources/Vexil/Flag.swift
@@ -25,6 +25,10 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
         return self.decorator.key!
     }
 
+    public var projectedValue: Flag<Value> {
+        return self
+    }
+
 
     // MARK: - Initialisation
 

--- a/Sources/Vexil/Flag.swift
+++ b/Sources/Vexil/Flag.swift
@@ -43,9 +43,26 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
     internal func decorate (lookup: Lookup, label: String, codingPath: [String]) {
         self.decorator.lookup = lookup
 
-        let codingKey = self.codingKeyStrategy.codingKey(label: label)
-            ?? lookup.codingKey(label: label)
-        self.decorator.key = (codingPath + [codingKey])
-            .joined(separator: lookup._configuration.separator)
+        var action = self.codingKeyStrategy.codingKey(label: label)
+        if action == .default {
+            action = lookup.codingKey(label: label)
+        }
+
+        switch action {
+
+        case .append(let string):
+            self.decorator.key = (codingPath + [string])
+                .joined(separator: lookup._configuration.separator)
+
+        case .absolute(let string):
+            self.decorator.key = string
+
+        // these two options should really never happen, but just in case, use what we've got
+        case .default, .skip:
+            assertionFailure("Invalid `CodingKeyAction` found when attempting to create key name for Flag \(self)")
+            self.decorator.key = (codingPath + [label])
+                .joined(separator: lookup._configuration.separator)
+
+        }
     }
 }

--- a/Sources/Vexil/Lookup.swift
+++ b/Sources/Vexil/Lookup.swift
@@ -11,7 +11,7 @@ internal protocol Lookup: AnyObject {
     var _configuration: VexilConfiguration { get }
 
     func lookup<Value> (key: String) -> Value? where Value: FlagValue
-    func codingKey (label: String) -> String
+    func codingKey (label: String) -> CodingKeyAction
 }
 
 extension FlagPole: Lookup {
@@ -22,7 +22,7 @@ extension FlagPole: Lookup {
             .first
     }
 
-    func codingKey (label: String) -> String {
+    func codingKey (label: String) -> CodingKeyAction {
         return self._configuration.codingPathStrategy.codingKey(label: label)
     }
 }

--- a/Sources/Vexil/Pole.swift
+++ b/Sources/Vexil/Pole.swift
@@ -71,14 +71,18 @@ public class FlagPole<RootGroup> where RootGroup: FlagContainer {
     }
 
     private func decorateRootGroup () {
-        let prefix = self._configuration.prefix ?? ""
+
+        var codingPath: [String] = []
+        if let prefix = self._configuration.prefix {
+            codingPath.append(prefix)
+        }
 
         Mirror(reflecting: self._rootGroup)
             .children
             .lazy
             .decorated
             .forEach {
-                $0.value.decorate(lookup: self, label: $0.label, codingPath: [ prefix ])
+                $0.value.decorate(lookup: self, label: $0.label, codingPath: codingPath)
             }
     }
 

--- a/Tests/VexilTests/KeyEncodingTests.swift
+++ b/Tests/VexilTests/KeyEncodingTests.swift
@@ -1,0 +1,112 @@
+//
+//  KeyEncodingTests.swift
+//  Vexil
+//
+//  Created by Rob Amos on 10/7/20.
+//
+
+import Vexil
+import XCTest
+
+final class KeyEncodingTests: XCTestCase {
+
+    func testKebabCaseCodingKeyStrategy () {
+        let config = VexilConfiguration(codingPathStrategy: .kebabcase, prefix: nil, separator: ".")
+        let pole = FlagPole(hoist: TestFlags.self, configuration: config, sources: [])
+
+        XCTAssertEqual(pole.$topLevelFlag.key, "top-level-flag")
+        XCTAssertEqual(pole.oneFlagGroup.$secondLevelFlag.key, "one-flag-group.second-level-flag")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.$thirdLevelFlag.key, "one-flag-group.two.third-level-flag")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.$thirdLevelFlag2.key, "one-flag-group.two.third-level-flag2")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$custom.key, "one-flag-group.two.customKey")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$full.key, "customKeyPath")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$standard.key, "one-flag-group.two.standard")
+    }
+
+    func testSnakeCaseCodingKeyStrategy () {
+        let config = VexilConfiguration(codingPathStrategy: .snakecase, prefix: nil, separator: ".")
+        let pole = FlagPole(hoist: TestFlags.self, configuration: config, sources: [])
+
+        XCTAssertEqual(pole.$topLevelFlag.key, "top_level_flag")
+        XCTAssertEqual(pole.oneFlagGroup.$secondLevelFlag.key, "one_flag_group.second_level_flag")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.$thirdLevelFlag.key, "one_flag_group.two.third_level_flag")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.$thirdLevelFlag2.key, "one_flag_group.two.third_level_flag2")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$custom.key, "one_flag_group.two.customKey")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$full.key, "customKeyPath")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$standard.key, "one_flag_group.two.standard")
+    }
+
+    func testPrefixCodingKeyStrategy () {
+        let config = VexilConfiguration(codingPathStrategy: .kebabcase, prefix: "prefix", separator: ".")
+        let pole = FlagPole(hoist: TestFlags.self, configuration: config, sources: [])
+
+        XCTAssertEqual(pole.$topLevelFlag.key, "prefix.top-level-flag")
+        XCTAssertEqual(pole.oneFlagGroup.$secondLevelFlag.key, "prefix.one-flag-group.second-level-flag")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.$thirdLevelFlag.key, "prefix.one-flag-group.two.third-level-flag")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.$thirdLevelFlag2.key, "prefix.one-flag-group.two.third-level-flag2")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$custom.key, "prefix.one-flag-group.two.customKey")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$full.key, "customKeyPath")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$standard.key, "prefix.one-flag-group.two.standard")
+    }
+
+    func testCustomSeparatorCodingKeyStrategy () {
+        let config = VexilConfiguration(codingPathStrategy: .kebabcase, prefix: "prefix", separator: "/")
+        let pole = FlagPole(hoist: TestFlags.self, configuration: config, sources: [])
+
+        XCTAssertEqual(pole.$topLevelFlag.key, "prefix/top-level-flag")
+        XCTAssertEqual(pole.oneFlagGroup.$secondLevelFlag.key, "prefix/one-flag-group/second-level-flag")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.$thirdLevelFlag.key, "prefix/one-flag-group/two/third-level-flag")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.$thirdLevelFlag2.key, "prefix/one-flag-group/two/third-level-flag2")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$custom.key, "prefix/one-flag-group/two/customKey")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$full.key, "customKeyPath")
+        XCTAssertEqual(pole.oneFlagGroup.twoFlagGroup.flagGroupThree.$standard.key, "prefix/one-flag-group/two/standard")
+    }
+}
+
+
+// MARK: - Fixtures
+
+struct TestFlags: FlagContainer {
+
+    @FlagGroup(description: "Test 1")
+    var oneFlagGroup: OneFlags
+
+    @Flag(default: false, description: "Top level test flag")
+    var topLevelFlag: Bool
+
+}
+
+struct OneFlags: FlagContainer {
+
+    @FlagGroup(codingKeyStrategy: .customKey("two"), description: "Test Two")
+    var twoFlagGroup: TwoFlags
+
+    @Flag(default: false, description: "Second level test flag")
+    var secondLevelFlag: Bool
+}
+
+struct TwoFlags: FlagContainer {
+
+    @FlagGroup(codingKeyStrategy: .skip, description: "Skipping test 3")
+    var flagGroupThree: ThreeFlags
+
+    @Flag(default: false, description: "Third level test flag")
+    var thirdLevelFlag: Bool
+
+    @Flag(default: false, description: "Second Third level test flag")
+    var thirdLevelFlag2: Bool
+
+}
+
+struct ThreeFlags: FlagContainer {
+
+    @Flag(codingKeyStrategy: .customKey("customKey"), default: false, description: "Test flag with custom key")
+    var custom: Bool
+
+    @Flag(codingKeyStrategy: .customKeyPath("customKeyPath"), default: false, description: "Test flag with custom key path")
+    var full: Bool
+
+    @Flag(default: true, description: "Standard Flag")
+    var standard: Bool
+
+}


### PR DESCRIPTION
This PR adds the ability to create a flag with a CodingKeyStrategy that is an absolute or fully qualified key.

eg.

```swift
@Flag(codingKeyStrategy: .customKeyPath("mytestkey"), default: false, description: "...")
var testKey: Bool
```

Would use a key of `mytestkey`, regardless of where in the Flag hierarchy it lives.

This allows us to continue to use the FlagContainer hierarchy as it makes sense, but support `FlagValueSource`s that use a custom key naming scheme

## Items of Note

To align the naming better, `.custom` was renamed to `.customKey`