### PR TITLE
Added support for custom display names

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -80,6 +80,7 @@ nesting:
 
 included:
   - "Sources"
+  - "Tests"
 
 excluded:
   - "Package.swift"

--- a/Sources/Vexil/Flag.swift
+++ b/Sources/Vexil/Flag.swift
@@ -13,6 +13,7 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
     // MARK: - Properties
 
     public var id = UUID()
+    public var name: String?
     public var description: String
     public var defaultValue: Value
 
@@ -32,7 +33,8 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
 
     // MARK: - Initialisation
 
-    public init (codingKeyStrategy: CodingKeyStrategy = .default, default initialValue: Value, description: String) {
+    public init (name: String? = nil, codingKeyStrategy: CodingKeyStrategy = .default, default initialValue: Value, description: String) {
+        self.name = name
         self.codingKeyStrategy = codingKeyStrategy
         self.description = description
         self.defaultValue = initialValue

--- a/Sources/Vexil/Group.swift
+++ b/Sources/Vexil/Group.swift
@@ -11,6 +11,7 @@ import Foundation
 public struct FlagGroup<Group>: Decorated, Identifiable where Group: FlagContainer {
 
     public let id = UUID()
+    public var name: String?
     public var description: String
 
     public var wrappedValue: Group
@@ -18,7 +19,8 @@ public struct FlagGroup<Group>: Decorated, Identifiable where Group: FlagContain
 
     // MARK: - Initialisation
 
-    public init (codingKeyStrategy: CodingKeyStrategy = .default, description: String) {
+    public init (name: String? = nil, codingKeyStrategy: CodingKeyStrategy = .default, description: String) {
+        self.name = name
         self.codingKeyStrategy = codingKeyStrategy
         self.description = description
         self.wrappedValue = Group()

--- a/Sources/Vexil/Group.swift
+++ b/Sources/Vexil/Group.swift
@@ -57,7 +57,6 @@ public struct FlagGroup<Group>: Decorated, Identifiable where Group: FlagContain
         // these actions shouldn't be possible in theory
         case .absolute, .default:
             assertionFailure("Invalid `CodingKeyAction` found when attempting to create key name for FlagGroup \(self)")
-            break
 
         }
 

--- a/Tests/VexilTests/KeyEncodingTests.swift
+++ b/Tests/VexilTests/KeyEncodingTests.swift
@@ -5,6 +5,8 @@
 //  Created by Rob Amos on 10/7/20.
 //
 
+// swiftlint:disable let_var_whitespace
+
 import Vexil
 import XCTest
 

--- a/Tests/VexilTests/TestHelpers.swift
+++ b/Tests/VexilTests/TestHelpers.swift
@@ -7,11 +7,11 @@
 
 import XCTest
 
-public func AssertNoThrow (file: StaticString = #file, line: UInt = #line, _ expression: () throws -> ()) {
+public func AssertNoThrow (file: StaticString = #file, line: UInt = #line, _ expression: () throws -> Void) {
     XCTAssertNoThrow(try expression(), file: file, line: line)
 }
 
-public func AssertThrows<E> (error: E, file: StaticString = #file, line: UInt = #line, _ expression: () throws -> ()) where E: Equatable {
+public func AssertThrows<E> (error: E, file: StaticString = #file, line: UInt = #line, _ expression: () throws -> Void) where E: Equatable {
     var result: E?
     XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError in
         result = thrownError as? E
@@ -20,11 +20,10 @@ public func AssertThrows<E> (error: E, file: StaticString = #file, line: UInt = 
 }
 
 @discardableResult
-public func AssertThrows (file: StaticString = #file, line: UInt = #line, _ expression: () throws -> ()) -> Swift.Error? {
+public func AssertThrows (file: StaticString = #file, line: UInt = #line, _ expression: () throws -> Void) -> Swift.Error? {
     var result: Swift.Error?
     XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError in
         result = thrownError
     }
     return result
 }
-


### PR DESCRIPTION
Custom display names are used in Vexillographer in place of the auto-generated names based on the properties. They are optional and purely additive.