### PR TITLE
Fixed display of digits in Vexillographer property display names

### DIFF
--- a/Sources/Vexillographer/Unfurling/FlagContainer+Extensions.swift
+++ b/Sources/Vexillographer/Unfurling/FlagContainer+Extensions.swift
@@ -68,8 +68,10 @@ extension String {
         var wordStart = string.startIndex
         var searchRange = string.index(after: wordStart)..<string.endIndex
 
+        let uppercase = CharacterSet.uppercaseLetters.union(CharacterSet.decimalDigits)
+
         // Find next uppercase character
-        while let upperCaseRange = string.rangeOfCharacter(from: CharacterSet.uppercaseLetters, options: [], range: searchRange) {
+        while let upperCaseRange = string.rangeOfCharacter(from: uppercase, options: [], range: searchRange) {
             let untilUpperCase = wordStart..<upperCaseRange.lowerBound
             words.append(untilUpperCase)
 


### PR DESCRIPTION
Digits were previously largely ignored when calculating property display names in Vexillographer. This PR treats them as upper case characters for the sake of grouping.