### PR TITLE
Added optional FlagValueDisplay protocol to customise the display of flag values

### DIFF
--- a/Sources/Vexil/Value.swift
+++ b/Sources/Vexil/Value.swift
@@ -15,6 +15,10 @@ public protocol FlagValue: Codable {
     var boxedFlagValue: BoxedFlagValue { get }
 }
 
+public protocol FlagDisplayValue: FlagValue {
+    var flagDisplayValue: String { get }
+}
+
 // MARK: - Boxed Flag Values
 
 /// An intermediate type used to make encoding and decoding of types simpler for `FlagValueSource`s


### PR DESCRIPTION
You can now conform FlagValues, especially `CaseIterable` flag values, to `FlagValueDisplay` to customise how the flag values are displayed in Vexillographer