### PR TITLE
Packaged name and description into a FlagInfo type and a .hidden option for hiding items from Vexillographer

### DIFF
--- a/Sources/Vexil/Flag.swift
+++ b/Sources/Vexil/Flag.swift
@@ -13,8 +13,7 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
     // MARK: - Properties
 
     public var id = UUID()
-    public var name: String?
-    public var description: String
+    public var info: FlagInfo
     public var defaultValue: Value
 
     public var wrappedValue: Value {
@@ -33,11 +32,13 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
 
     // MARK: - Initialisation
 
-    public init (name: String? = nil, codingKeyStrategy: CodingKeyStrategy = .default, default initialValue: Value, description: String) {
-        self.name = name
+    public init (name: String? = nil, codingKeyStrategy: CodingKeyStrategy = .default, default initialValue: Value, description: FlagInfo) {
         self.codingKeyStrategy = codingKeyStrategy
-        self.description = description
         self.defaultValue = initialValue
+
+        var info = description
+        info.name = name
+        self.info = info
     }
 
 

--- a/Sources/Vexil/FlagInfo.swift
+++ b/Sources/Vexil/FlagInfo.swift
@@ -1,0 +1,49 @@
+//
+//  FlagInfo.swift
+//  Vexil
+//
+//  Created by Rob Amos on 15/7/20.
+//
+
+public struct FlagInfo {
+
+    // MARK: - Properties
+
+    /// The name of the flag or flag group, if nil it is calculated from the containing property name
+    public var name: String?
+
+    /// A brief description of the flag or flag group's purpose
+    public var description: String
+
+    /// Whether or not the flag or flag group should be visible in Vexillographer
+    public var shouldDisplay: Bool
+
+
+    // MARK: - Initialisation
+
+    init (name: String?, description: String, shouldDisplay: Bool) {
+        self.name = name
+        self.description = description
+        self.shouldDisplay = shouldDisplay
+    }
+
+    public init (description: String) {
+        self.init(name: nil, description: description, shouldDisplay: true)
+    }
+}
+
+
+// MARK: - Hidden Flags
+
+public extension FlagInfo {
+    static let hidden = FlagInfo(name: nil, description: "", shouldDisplay: false)
+}
+
+
+// MARK: - String Literal Support
+
+extension FlagInfo: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self.init(name: nil, description: value, shouldDisplay: true)
+    }
+}

--- a/Sources/Vexil/Group.swift
+++ b/Sources/Vexil/Group.swift
@@ -11,26 +11,27 @@ import Foundation
 public struct FlagGroup<Group>: Decorated, Identifiable where Group: FlagContainer {
 
     public let id = UUID()
-    public var name: String?
-    public var description: String
+    public let info: FlagInfo
 
     public var wrappedValue: Group
 
 
     // MARK: - Initialisation
 
-    public init (name: String? = nil, codingKeyStrategy: CodingKeyStrategy = .default, description: String) {
-        self.name = name
+    public init (name: String? = nil, codingKeyStrategy: CodingKeyStrategy = .default, description: FlagInfo) {
         self.codingKeyStrategy = codingKeyStrategy
-        self.description = description
         self.wrappedValue = Group()
+
+        var info = description
+        info.name = name
+        self.info = info
     }
 
     /// An internal initialiser used so we can create Snapshtos that are decoupled from everything
     internal init (group: Group) {
         self.codingKeyStrategy = .default
-        self.description = ""
         self.wrappedValue = group
+        self.info = .hidden
     }
 
 


### PR DESCRIPTION
Packaged the flag/group name and description into a `FlagInfo` struct, akin to swift-argument-parser's `ArgumentHelp`.

This also provides a `.hidden` static var that can be used to hide a flag or flag group from display in Vexillographer.