### PR TITLE
Added support for TextField and Picker flag editing controls

### DIFF
--- a/Sources/Vexillographer/Flag Value Controls/Binding.swift
+++ b/Sources/Vexillographer/Flag Value Controls/Binding.swift
@@ -5,24 +5,71 @@
 //  Created by Rob Amos on 29/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import SwiftUI
 import Vexil
 
 extension Binding {
-    init<RootGroup> (flag: UnfurledFlag<Value, RootGroup>, manager: FlagValueManager<RootGroup>) {
+    init<Transformer, RootGroup> (key: String, manager: FlagValueManager<RootGroup>, defaultValue: Transformer.OriginalValue, transformer: Transformer.Type) where RootGroup: FlagContainer, Transformer: FlagValueTransformer, Transformer.EditingValue == Value {
         self.init (
-            get: { flag.flag.wrappedValue },
+            get: {
+                let value: Transformer.OriginalValue = manager.flagValue(key: key) ?? defaultValue
+                return transformer.toEditingValue(value)
+            },
             set: { newValue in
                 do {
-                    try manager.setFlagValue(newValue, key: flag.flag.key)
+                    let value = transformer.toOriginalValue(newValue)
+                    try manager.setFlagValue(value, key: key)
 
                 } catch {
-                    print("[Vexilographer] Could not set flag with key \"\(flag.flag.key)\" to \"\(newValue)\"")
+                    print("[Vexilographer] Could not set flag with key \"\(key)\" to \"\(newValue)\"")
                 }
             }
         )
+    }
+}
+
+
+// MARK: - Flag Value Transformers
+
+/// Describes a type that can be used to transform Flag Values for editing
+///
+protocol FlagValueTransformer {
+    associatedtype OriginalValue: FlagValue
+    associatedtype EditingValue: FlagValue
+
+    static func toEditingValue (_ value: OriginalValue) -> EditingValue
+    static func toOriginalValue (_ value: EditingValue) -> OriginalValue?
+}
+
+/// A simple transformer that passes the value through as the same type
+///
+struct PassthroughTransformer<Value>: FlagValueTransformer where Value: FlagValue {
+    typealias OriginalValue = Value
+    typealias EditingValue = Value
+
+    static func toEditingValue(_ value: OriginalValue) -> Value {
+        return value
+    }
+
+    static func toOriginalValue(_ value: Value) -> OriginalValue? {
+        return value
+    }
+}
+
+/// A simple transformer that converts a FlagValue into a string for editing with a TextField
+///
+struct LosslessStringTransformer<Value>: FlagValueTransformer where Value: FlagValue, Value: LosslessStringConvertible {
+    typealias OriginalValue = Value
+    typealias EditingValue = String
+
+    static func toEditingValue(_ value: Value) -> String {
+        value.description
+    }
+
+    static func toOriginalValue(_ value: String) -> Value? {
+        Value(value)
     }
 }
 

--- a/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 29/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import SwiftUI
 import Vexil
@@ -15,13 +15,30 @@ struct BooleanFlagControl: View {
     // MARK: - Properties
 
     let label: String
+    @Binding var showDetail: Bool
     @Binding var flagValue: Bool
-
 
     // MARK: - Views
 
     var body: some View {
-        Toggle(self.label, isOn: self.$flagValue)
+        HStack {
+            Toggle(self.label, isOn: self.$flagValue)
+            DetailButton(showDetail: self.$showDetail)
+        }
+    }
+}
+
+
+// MARK: - Flag Control Creation
+
+protocol BooleanEditableFlag {
+    func control<RootGroup> (label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> BooleanFlagControl where RootGroup: FlagContainer
+}
+
+extension UnfurledFlag: BooleanEditableFlag where Value == Bool {
+    func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> BooleanFlagControl where RootGroup: FlagContainer {
+        let binding = Binding(key: self.flag.key, manager: manager, defaultValue: self.flag.defaultValue, transformer: PassthroughTransformer<Value>.self)
+        return BooleanFlagControl (label: label,showDetail: showDetail, flagValue: binding)
     }
 }
 

--- a/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
@@ -38,7 +38,7 @@ protocol BooleanEditableFlag {
 extension UnfurledFlag: BooleanEditableFlag where Value == Bool {
     func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> BooleanFlagControl where RootGroup: FlagContainer {
         let binding = Binding(key: self.flag.key, manager: manager, defaultValue: self.flag.defaultValue, transformer: PassthroughTransformer<Value>.self)
-        return BooleanFlagControl (label: label,showDetail: showDetail, flagValue: binding)
+        return BooleanFlagControl (label: label, showDetail: showDetail, flagValue: binding)
     }
 }
 

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -1,0 +1,56 @@
+//
+//  CaseIterableFlagControl.swift
+//  Vexil: Vexillographer
+//
+//  Created by Rob Amos on 14/7/20.
+//
+
+// swiftlint:disable multiple_closures_with_trailing_closure
+
+#if os(iOS) || os(macOS)
+
+import SwiftUI
+import Vexil
+
+struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseIterable, Value: Hashable, Value.AllCases: RandomAccessCollection {
+
+    // MARK: - Properties
+
+    let label: String
+    @Binding var flagValue: Value
+    @Binding var showDetail: Bool
+
+    @State private var showPicker = false
+
+    // MARK: - View Body
+
+    var body: some View {
+        VStack {
+            HStack {
+                Picker(self.label, selection: self.$flagValue) {
+                    ForEach(Value.allCases, id: \.self) { value in
+                        FlagDisplayValueView(value: value)
+                    }
+                }
+                DetailButton(showDetail: self.$showDetail)
+            }
+        }
+    }
+
+}
+
+protocol CaseIterableEditableFlag {
+    func control<RootGroup> (label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer
+}
+
+extension UnfurledFlag: CaseIterableEditableFlag
+            where Value: FlagValue, Value: CaseIterable, Value.AllCases: RandomAccessCollection,
+                  Value: RawRepresentable, Value.RawValue: FlagValue, Value: Hashable {
+    func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer {
+        let binding = Binding(key: self.flag.key, manager: manager, defaultValue: self.flag.defaultValue, transformer: PassthroughTransformer<Value>.self)
+        return CaseIterableFlagControl<Value>(label: label, flagValue: binding, showDetail: showDetail)
+            .eraseToAnyView()
+    }
+}
+
+#endif

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -5,8 +5,6 @@
 //  Created by Rob Amos on 14/7/20.
 //
 
-// swiftlint:disable multiple_closures_with_trailing_closure
-
 #if os(iOS) || os(macOS)
 
 import SwiftUI

--- a/Sources/Vexillographer/Flag Value Controls/DetailButton.swift
+++ b/Sources/Vexillographer/Flag Value Controls/DetailButton.swift
@@ -1,0 +1,41 @@
+//
+//  DetailButton.swift
+//  Vexil: Vexillographer
+//
+//  Created by Rob Amos on 15/7/20.
+//
+
+#if os(iOS) || os(macOS)
+
+import SwiftUI
+
+struct DetailButton: View {
+
+    // MARK: - Properties
+
+    @Binding var showDetail: Bool
+
+
+    // MARK: - View
+
+#if os(iOS)
+
+    var body: some View {
+        Button (
+            action: {},
+            label: { Image(systemName: "info.circle") }
+        )
+            .onTapGesture { self.showDetail.toggle() }
+    }
+
+#elseif os(macOS)
+
+    var body: some View {
+        EmptyView()
+    }
+
+#endif
+
+}
+
+#endif

--- a/Sources/Vexillographer/Flag Value Controls/FlagDisplayValueView.swift
+++ b/Sources/Vexillographer/Flag Value Controls/FlagDisplayValueView.swift
@@ -1,0 +1,33 @@
+//
+//  FlagDisplayView.swift
+//  Vexil: Vexillographer
+//
+//  Created by Rob Amos on 15/7/20.
+//
+
+#if os(iOS) || os(macOS)
+
+import SwiftUI
+import Vexil
+
+struct FlagDisplayValueView<Value>: View where Value: FlagValue {
+
+    // MARK: - Properties
+
+    let value: Value
+
+
+    // MARK: - Body
+
+    var body: some View {
+        if let value = self.value as? FlagDisplayValue {
+            return Text(value.flagDisplayValue)
+
+        } else {
+            return Text(String(describing: self.value).displayName)
+        }
+    }
+
+}
+
+#endif

--- a/Sources/Vexillographer/Flag Value Controls/StringFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/StringFlagControl.swift
@@ -1,0 +1,109 @@
+//
+//  BooleanFlagControl.swift
+//  Vexil: Vexilographer
+//
+//  Created by Rob Amos on 29/6/20.
+//
+
+#if os(iOS) || os(macOS)
+
+import SwiftUI
+import Vexil
+
+struct StringFlagControl: View {
+
+    // MARK: - Properties
+
+    let label: String
+    @Binding var flagValue: String
+    @Binding var showDetail: Bool
+
+    #if os(iOS)
+    let keyboardType: UIKeyboardType
+    #endif
+
+
+    // MARK: - Views
+
+    var body: some View {
+        HStack {
+            Text(self.label)
+            Spacer()
+            self.textField
+            DetailButton(showDetail: self.$showDetail)
+        }
+    }
+
+
+    #if os(iOS)
+
+    var textField: some View {
+        TextField("", text: self.$flagValue)
+            .multilineTextAlignment(.trailing)
+            .keyboardType(self.keyboardType)
+    }
+
+    #elseif os(macOS)
+
+    var textField: some View {
+        TextField("", text: self.$flagValue)
+            .multilineTextAlignment(.trailing)
+    }
+
+    #endif
+}
+
+
+// MARK: - Flag Control
+
+protocol StringEditableFlag {
+    func control<RootGroup> (label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> StringFlagControl where RootGroup: FlagContainer
+}
+
+#if os(macOS)
+
+extension UnfurledFlag: StringEditableFlag where Value: LosslessStringConvertible {
+    func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> StringFlagControl where RootGroup: FlagContainer {
+        return StringFlagControl (
+            label: label,
+            flagValue: Binding(key: self.flag.key, manager: manager, defaultValue: self.flag.defaultValue, transformer: LosslessStringTransformer<Value>.self),
+            showDetail: showDetail
+        )
+    }
+}
+
+#elseif os(iOS)
+
+extension UnfurledFlag: StringEditableFlag where Value: LosslessStringConvertible {
+    func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> StringFlagControl where RootGroup: FlagContainer {
+        return StringFlagControl (
+            label: label,
+            flagValue: Binding(key: self.flag.key, manager: manager, defaultValue: self.flag.defaultValue, transformer: LosslessStringTransformer<Value>.self),
+            showDetail: showDetail,
+            keyboardType: Value.keyboardType
+        )
+    }
+}
+
+private extension FlagValue {
+
+    /// Provides a hint as to what keyboard type to use for a given FlagValue
+    ///
+    static var keyboardType: UIKeyboardType {
+        if Self.self == Double.self || Self.self == Float.self {
+            return .decimalPad
+
+        } else if Self.self == Int.self || Self.self == Int8.self || Self.self == Int16.self
+         || Self.self == Int32.self || Self.self == Int64.self || Self.self == UInt.self
+         || Self.self == UInt8.self || Self.self == UInt16.self || Self.self == UInt32.self
+         || Self.self == UInt64.self {
+            return .numberPad
+        }
+
+        return .default
+    }
+}
+
+#endif
+
+#endif

--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 29/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import SwiftUI
 import Vexil
@@ -33,7 +33,7 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
 
     var body: some View {
         self.content
-            .navigationBarTitle(Text(self.flag.name), displayMode: .inline)
+            .navigationBarTitle(Text(self.flag.info.name), displayMode: .inline)
     }
 
     #else
@@ -46,9 +46,10 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
 
 
     var content: some View {
-        List {
-            Text(self.flag.description)
-                .font(.footnote)
+        Form {
+            Section(header: Text("Description")) {
+                Text(self.flag.info.description)
+            }
 
             Section(header: Text("Current Source")) {
                 HStack {
@@ -67,7 +68,7 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
                 }
             }
 
-            Section(header: Text("Flag Pole's Source Hierarchy")) {
+            Section(header: Text("FlagPole Source Hierarchy")) {
                 ForEach(0 ..< self.manager.flagPole._sources.count) { index in
                     HStack {
                         Text(self.manager.flagPole._sources[index].name)

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 16/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import SwiftUI
 import Vexil
@@ -32,7 +32,7 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
 
     var body: some View {
         self.content
-            .navigationBarTitle(Text(self.group.name), displayMode: .inline)
+            .navigationBarTitle(Text(self.group.info.name), displayMode: .inline)
     }
 
     #else
@@ -45,10 +45,10 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
 
     var content: some View {
         Form {
-            Section {
-                Text(self.group.description)
+            Section(header: Text("Description")) {
+                Text(self.group.info.description)
             }
-            Section {
+            Section(header: Text("Flags")) {
                 ForEach(self.group.allItems(), id: \.id) { item in
                     item.unfurledView
                 }

--- a/Sources/Vexillographer/FlagValueManager.swift
+++ b/Sources/Vexillographer/FlagValueManager.swift
@@ -5,7 +5,7 @@
 // Created by Rob Amos on 29/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import Combine
 import Foundation
@@ -37,7 +37,12 @@ class FlagValueManager<RootGroup>: ObservableObject where RootGroup: FlagContain
     }
 
 
-    // MARK: - Updating Flag Values
+    // MARK: - Flag Values
+
+    func flagValue<Value> (key: String) -> Value? where Value: FlagValue {
+        let snapshot = self.flagPole.snapshot()
+        return snapshot.flagValue(key: key)
+    }
 
     func setFlagValue<Value> (_ value: Value?, key: String) throws where Value: FlagValue {
         let snapshot = self.flagPole.emptySnapshot()
@@ -54,7 +59,6 @@ class FlagValueManager<RootGroup>: ObservableObject where RootGroup: FlagContain
             .compactMap { child -> UnfurledFlagItem? in
                 guard let label = child.label, let unfurlable = child.value as? Unfurlable else { return nil }
                 let unfurled = unfurlable.unfurl(label: label, manager: self)
-                print("\(unfurled.name) - \(unfurled.id)")
                 return unfurled
             }
     }

--- a/Sources/Vexillographer/Unfurling/Unfurlable.swift
+++ b/Sources/Vexillographer/Unfurling/Unfurlable.swift
@@ -1,0 +1,42 @@
+//
+//  Unfurlable.swift
+//  Vexil: Vexilographer
+//
+//  Created by Rob Amos on 15/6/20.
+//
+
+#if os(iOS) || os(macOS)
+
+import Foundation
+import Vexil
+
+/// Describes a type that can "unfurl" itself.
+///
+/// Basically this is used to provide the Flag and FlagGroups with a way to create a type-erased `UnfurledFlagItem`
+/// that describes themelves.
+///
+protocol Unfurlable {
+    func unfurl<RootGroup> (label: String, manager: FlagValueManager<RootGroup>) -> UnfurledFlagItem? where RootGroup: FlagContainer
+}
+
+extension Flag: Unfurlable where Value: FlagValue {
+
+    /// Creates an `UnfurledFlag` from the receiver and returns it as a type-erased `UnfurledFlagItem`
+    ///
+    func unfurl<RootGroup> (label: String, manager: FlagValueManager<RootGroup>) -> UnfurledFlagItem? where RootGroup: FlagContainer {
+        guard self.info.shouldDisplay == true else { return nil }
+        return UnfurledFlag(name: self.info.name ?? label.localizedDisplayName, flag: self, manager: manager)
+    }
+}
+
+extension FlagGroup: Unfurlable {
+
+    /// Creates an `UnfurledFlagGroup` from the receiver and returns it as a type-erased `UnfurledFlagItem`
+    ///
+    func unfurl<RootGroup>(label: String, manager: FlagValueManager<RootGroup>) -> UnfurledFlagItem? where RootGroup: FlagContainer {
+        guard self.info.shouldDisplay == true else { return nil }
+        return UnfurledFlagGroup(name: self.info.name ?? label.localizedDisplayName, group: self, manager: manager)
+    }
+}
+
+#endif

--- a/Sources/Vexillographer/Unfurling/UnfurledFlag.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlag.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 16/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import Foundation
 import SwiftUI
@@ -15,7 +15,7 @@ struct UnfurledFlag<Value, RootGroup>: UnfurledFlagItem, Identifiable where Valu
 
     // MARK: - Properties
 
-    let name: String
+    let info: UnfurledFlagInfo
     let flag: Flag<Value>
     let hasChildren = false
 
@@ -29,17 +29,13 @@ struct UnfurledFlag<Value, RootGroup>: UnfurledFlagItem, Identifiable where Valu
     // MARK: - Initialisation
 
     init (name: String, flag: Flag<Value>, manager: FlagValueManager<RootGroup>) {
-        self.name = name
+        self.info = UnfurledFlagInfo(info: flag.info, defaultName: name)
         self.flag = flag
         self.manager = manager
     }
 
 
     // MARK: - Unfurled Flag Item Conformance
-
-    var description: String {
-        return self.flag.description
-    }
 
     var unfurledView: AnyView {
         return AnyView(UnfurledFlagView(flag: self, manager: self.manager))

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 16/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import Foundation
 import SwiftUI
@@ -15,7 +15,7 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
 
     // MARK: - Properties
 
-    let name: String
+    let info: UnfurledFlagInfo
     let group: FlagGroup<Group>
     let hasChildren = true
 
@@ -29,17 +29,13 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
     // MARK: - Initialisation
 
     init (name: String, group: FlagGroup<Group>, manager: FlagValueManager<Root>) {
-        self.name = name
+        self.info = UnfurledFlagInfo(info: group.info, defaultName: name)
         self.group = group
         self.manager = manager
     }
 
 
     // MARK: - Unfurled Flag Item Conformance
-
-    var description: String {
-        return self.group.description
-    }
 
     func allItems () -> [UnfurledFlagItem] {
         return Mirror(reflecting: self.group.wrappedValue)
@@ -53,7 +49,8 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
     var unfurledView: AnyView {
         return NavigationLink(destination: UnfurledFlagGroupView(group: self, manager: self.manager)) {
             HStack {
-                Text(self.name)
+                Text(self.info.name)
+                    .font(.headline)
             }
         }
             .eraseToAnyView()

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagInfo.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagInfo.swift
@@ -1,0 +1,31 @@
+//
+//  UnfurledFlagInfo.swift
+//  Vexil: Vexillographer
+//
+//  Created by Rob Amos on 15/7/20.
+//
+
+#if os(iOS) || os(macOS)
+
+import Vexil
+
+struct UnfurledFlagInfo {
+
+    // MARK: - Properties
+
+    /// The name of the unfurled flag or flag group
+    let name: String
+
+    /// A brief description of the unfurled flag or flag group
+    let description: String
+
+
+    // MARK: - Initialisation
+
+    init (info: FlagInfo, defaultName: String) {
+        self.name = info.name ?? defaultName
+        self.description = info.description
+    }
+}
+
+#endif

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 16/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import Foundation
 import SwiftUI
@@ -13,8 +13,7 @@ import Vexil
 
 protocol UnfurledFlagItem {
     var id: UUID { get }
-    var name: String { get }
-    var description: String { get }
+    var info: UnfurledFlagInfo { get }
     var hasChildren: Bool { get }
     var unfurledView: AnyView { get }
 }

--- a/Sources/Vexillographer/Utilities/AnyView.swift
+++ b/Sources/Vexillographer/Utilities/AnyView.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 29/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import SwiftUI
 

--- a/Sources/Vexillographer/Utilities/DisplayName.swift
+++ b/Sources/Vexillographer/Utilities/DisplayName.swift
@@ -1,41 +1,24 @@
 //
-//  FlagContainer+Extensions.swift
-//  Vexil: Vexilographer
+//  DisplayName.swift
+//  Vexil: Vexillographer
 //
-//  Created by Rob Amos on 15/6/20.
+//  Created by Rob Amos on 15/7/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import Foundation
-import Vexil
-
-protocol Unfurlable {
-    func unfurl<RootGroup> (label: String, manager: FlagValueManager<RootGroup>) -> UnfurledFlagItem where RootGroup: FlagContainer
-}
-
-extension Flag: Unfurlable {
-    func unfurl<RootGroup> (label: String, manager: FlagValueManager<RootGroup>) -> UnfurledFlagItem where RootGroup: FlagContainer {
-        return UnfurledFlag(name: self.name ?? label.localizedPropertyDisplayName, flag: self, manager: manager)
-    }
-}
-
-extension FlagGroup: Unfurlable {
-    func unfurl<RootGroup>(label: String, manager: FlagValueManager<RootGroup>) -> UnfurledFlagItem where RootGroup: FlagContainer {
-        return UnfurledFlagGroup(name: self.name ?? label.localizedPropertyDisplayName, group: self, manager: manager)
-    }
-}
 
 extension String {
-    var localizedPropertyDisplayName: String {
-        return self.propertyDisplayName(with: Locale.autoupdatingCurrent)
+    var localizedDisplayName: String {
+        return self.displayName(with: Locale.autoupdatingCurrent)
     }
 
-    var propertyDisplayName: String {
-        return self.propertyDisplayName(with: nil)
+    var displayName: String {
+        return self.displayName(with: nil)
     }
 
-    func propertyDisplayName (with locale: Locale?) -> String {
+    func displayName (with locale: Locale?) -> String {
         let uppercased = CharacterSet.uppercaseLetters
         return (self.hasPrefix("_") ? String(self.dropFirst()) : self)
             .separatedAtWordBoundaries

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 14/6/20.
 //
 
-#if !os(Linux)
+#if os(iOS) || os(macOS)
 
 import SwiftUI
 import Vexil


### PR DESCRIPTION
This Pull Request:

- Refactors support for `Toggle`-based editing of `Bool` flag values
- Adds `TextField`-based editing of any flag value that conforms to `LosslessStringConvertible`
- Adds `Picker`-based editing of any flag value that is `RawRepresentable && CaseIterable`

And completes the initial feature set for Vexil 1.0.