### PR TITLE
Removed the explicit `Form` used in the Vexillographer view as this limits how the view can be consumed

### DIFF
--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -27,12 +27,10 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
     // MARK: - Body
 
     public var body: some View {
-        Form {
-            ForEach(self.manager.allItems(), id: \.id) { item in
-                item.unfurledView
-            }
-                .environmentObject(self.manager)
+        ForEach(self.manager.allItems(), id: \.id) { item in
+            item.unfurledView
         }
+            .environmentObject(self.manager)
     }
 }
 


### PR DESCRIPTION
Documentation and examples will be provided for the suggested use instead:

```swift
Form {
    Vexillographer(...)
}
```