### PR TITLE
Identified the current source (if known) in the Vexillographer hierarchy display

### DIFF
--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -54,6 +54,7 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
             Section(header: Text("Current Source")) {
                 HStack {
                     Text(self.manager.source.name)
+                        .font(.headline)
                     Spacer()
                     self.description(source: self.manager.source)
                 }
@@ -71,7 +72,12 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
             Section(header: Text("FlagPole Source Hierarchy")) {
                 ForEach(0 ..< self.manager.flagPole._sources.count) { index in
                     HStack {
-                        Text(self.manager.flagPole._sources[index].name)
+                        if (self.manager.flagPole._sources[index] as AnyObject) === (self.manager.source as AnyObject) {
+                            Text(self.manager.flagPole._sources[index].name)
+                                .font(.headline)
+                        } else {
+                            Text(self.manager.flagPole._sources[index].name)
+                        }
                         Spacer()
                         self.description(source: self.manager.flagPole._sources[index])
                     }


### PR DESCRIPTION
This uses the lazy approach of casting to `AnyObject` and using `===` to check whether they are the same object. This is likely to be error prone but I did not want to ask `FlagValueSource` to conform to `Hashable` or `Equatable` just for a styling opportunity in the FlagDetailView