### PR TITLE
Added a `Flag.publisher` property

### DIFF
--- a/Sources/Vexil/Lookup.swift
+++ b/Sources/Vexil/Lookup.swift
@@ -5,6 +5,10 @@
 //  Created by Rob Amos on 25/5/20.
 //
 
+#if !os(Linux)
+import Combine
+#endif
+
 import Foundation
 
 /// An internal protocol that is provided to each `Flag` when it is decorated.
@@ -15,6 +19,10 @@ import Foundation
 ///
 internal protocol Lookup: AnyObject {
     func lookup<Value> (key: String) -> Value? where Value: FlagValue
+
+    #if !os(Linux)
+    func publisher<Value> (key: String) -> AnyPublisher<Value, Never> where Value: FlagValue
+    #endif
 }
 
 extension FlagPole: Lookup {
@@ -33,4 +41,16 @@ extension FlagPole: Lookup {
         }
         return nil
     }
+
+    #if !os(Linux)
+
+    /// Retrieves a publsiher from the FlagPole that is bound to updates of a specific key
+    ///
+    func publisher<Value> (key: String) -> AnyPublisher<Value, Never> where Value: FlagValue {
+        self.publisher
+            .compactMap { $0.flagValue(key: key) }
+            .eraseToAnyPublisher()
+    }
+
+    #endif
 }

--- a/Sources/Vexil/Value.swift
+++ b/Sources/Vexil/Value.swift
@@ -5,25 +5,61 @@
 //  Created by Rob Amos on 25/5/20.
 //
 
-// swiftlint:disable extension_access_modifier
+// swiftlint:disable extension_access_modifier file_length
 
 import Foundation
 
+/// A type that represents the wrapped value of a `Flag`
+///
+/// This type exists solely so we can provide hints for boxing/unboxing or encoding/decoding
+/// into various `FlagValueSource`s.
+///
+/// See the full documentation for information and examples on using custom types
+/// with Vexil.
+///
 public protocol FlagValue {
+
+    /// The type that this `FlagValue` would be boxed into.
+    /// Used by `FlagValueSource`s to provide interop with different providers
+    ///
+    /// For `Codable` support, a default boxed type of `Data` is assumed if you
+    /// do not specify one directly.
+    ///
     associatedtype BoxedValueType = Data
 
+    /// When initialised with a BoxedFlagValue your conforming type must
+    /// be able to unbox and initialise itself. Return nil if you cannot successfully
+    /// unbox the flag value, or if it is an incompatible type.
+    ///
     init? (boxedFlagValue: BoxedFlagValue)
 
+    /// Your conforming type must return an instance of the BoxedFlagValue
+    /// with the boxed type included. This type should match the type
+    /// specified in the `BoxedValueType` assocaited type.
+    ///
     var boxedFlagValue: BoxedFlagValue { get }
 }
 
+/// A convenience protocol used by flag editors like Vexillographer.
+///
+/// Use this with your `CaseIterable` types when you want to customise
+/// the value displayed in the UI.
+///
+/// - Note: This is only used by types that are edited with a `Picker` (eg. those
+/// that are `CaseIterable`. It is not used by types that are edited
+/// with a `TextField` or `Toggle`.
+///
 public protocol FlagDisplayValue {
+
+    /// The value to display in the `Picker` for a given flag value
     var flagDisplayValue: String { get }
 }
 
 // MARK: - Boxed Flag Values
 
 /// An intermediate type used to make encoding and decoding of types simpler for `FlagValueSource`s
+///
+/// Any custom type you conform to `FlagValue` must be able to be represented using one of these types
 ///
 public enum BoxedFlagValue: Equatable {
     case array([BoxedFlagValue])


### PR DESCRIPTION
This is a convenience property to return a publisher that only emits values when the flag value has changed (if `Equatable`, all values otherwise).

### 🔍 Detailed Design

It adds this:

```swift
flagPole.subGroup.$myFlag.publisher
```

Which is really just a more convenient version of this:

```swift
flagPole.publisher
    .map { $0.subGroup.myFlag }
    .removeDuplicates()
```
