### PR TITLE
Subscribing to a Flag-specific publisher on a Snapshot now works with didSet instead of willSet

### DIFF
--- a/Sources/Vexil/Snapshots/Snapshot.swift
+++ b/Sources/Vexil/Snapshots/Snapshot.swift
@@ -62,11 +62,7 @@ public class Snapshot<RootGroup>: FlagValueSource where RootGroup: FlagContainer
 
     private var _rootGroup: RootGroup
 
-    #if !os(Linux)
-    @Published private var values: [String: Any] = [:]
-    #else
     private var values: [String: Any] = [:]
-    #endif
 
     internal var lock = Lock()
 
@@ -197,7 +193,7 @@ public class Snapshot<RootGroup>: FlagValueSource where RootGroup: FlagContainer
 
     // MARK: - Real Time Flag Changes
 
-    var valuesDidChange = SnapshotValueChanged()
+    private var valuesDidChange = SnapshotValueChanged()
 
 
     // MARK: - Errors
@@ -245,8 +241,10 @@ extension Snapshot: Lookup {
     #if !os(Linux)
 
     func publisher<Value>(key: String) -> AnyPublisher<Value, Never> where Value: FlagValue {
-        self.$values
-            .compactMap { $0[key] as? Value }
+        self.valuesDidChange
+            .compactMap { [weak self] _ in
+                self?.values[key] as? Value
+            }
             .eraseToAnyPublisher()
     }
 


### PR DESCRIPTION
We were previously using `@Published` inside the `Snapshot`, but because `@Published` is designed to work with `ObservableObject` it triggers updating values using `willSet` instead of `didSet`.

This means that the snapshot that was taken to send to subscribers was generated _before_ the value was actually updated internally.