### PR TITLE
Added a simple `FlagValueDictionary` source

### DIFF
--- a/Sources/Vexil/Sources/FlagValueDictionary.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary.swift
@@ -1,0 +1,117 @@
+//
+//  FlagValueDictionary.swift
+//  Vexil
+//
+//  Created by Rob Amos on 15/8/20.
+//
+
+#if !os(Linux)
+import Combine
+#endif
+
+import Foundation
+
+/// A simple dictionary-backed FlagValueSource that can be useful for testing
+/// and other purposes.
+///
+open class FlagValueDictionary: Identifiable, ExpressibleByDictionaryLiteral {
+
+    // MARK: - Properties
+
+    public let id = UUID()
+
+    public typealias DictionaryType = [String: Any]
+
+    internal var storage: DictionaryType {
+        didSet {
+            #if !os(Linux)
+            self.valueDidChange.send()
+            #endif
+        }
+    }
+
+    #if !os(Linux)
+    private var valueDidChange = PassthroughSubject<Void, Never>()
+    #endif
+
+
+    // MARK: - Initialisation
+
+    /// Initialises a `FlagValueDictionary` with the specified dictionary
+    ///
+    public init (_ dictionary: DictionaryType = [:]) {
+        self.storage = dictionary
+    }
+
+    public required init(dictionaryLiteral elements: (String, Any)...) {
+        self.storage = elements.reduce(into: [:]) { dict, pair in
+            dict.updateValue(pair.1, forKey: pair.0)
+        }
+    }
+
+}
+
+
+// MARK: - Flag Value Source
+
+extension FlagValueDictionary: FlagValueSource {
+    public var name: String {
+        return "\(String(describing: Self.self)): \(self.id.uuidString)"
+    }
+
+    public func flagValue<Value>(key: String) -> Value? where Value: FlagValue {
+        return self.storage[key] as? Value
+    }
+
+    public func setFlagValue<Value>(_ value: Value?, key: String) throws where Value: FlagValue {
+        if let value = value {
+            self.storage.updateValue(value, forKey: key)
+        } else {
+            self.storage.removeValue(forKey: key)
+        }
+    }
+
+    #if !os(Linux)
+
+    /// If you're running on a platform that supports Combine you can optionally support real-time
+    /// flag updates
+    ///
+    public var valuesDidChange: AnyPublisher<Void, Never>? {
+        self.valueDidChange
+            .eraseToAnyPublisher()
+    }
+
+    #endif
+}
+
+
+// MARK: - Collection
+
+extension FlagValueDictionary: Collection {
+
+    public typealias Index = DictionaryType.Index
+    public typealias Element = DictionaryType.Element
+
+    public var startIndex: Index { return self.storage.startIndex }
+    public var endIndex: Index { return self.storage.endIndex }
+
+    public subscript(index: Index) -> Iterator.Element {
+        return self.storage[index]
+    }
+
+    public subscript(key: Key) -> Value? {
+        get { return self.storage[key] }
+        set {
+            if let value = newValue {
+                self.storage.updateValue(value, forKey: key)
+            } else {
+                self.storage.removeValue(forKey: key)
+            }
+        }
+    }
+
+    public func index(after i: Index) -> Index {
+        return self.storage.index(after: i)
+    }
+
+}

--- a/Tests/VexilTests/FlagValueDictionaryTests.swift
+++ b/Tests/VexilTests/FlagValueDictionaryTests.swift
@@ -1,0 +1,101 @@
+//
+//  FlagValueDitionaryTests.swift
+//  Vexil
+//
+//  Created by Rob Amos on 17/8/20.
+//
+
+@testable import Vexil
+import XCTest
+
+final class FlagValueDictionaryTests: XCTestCase {
+
+    // MARK: - Reading Values
+
+    func testReadsValues () {
+        let source: FlagValueDictionary = [
+            "top-level-flag": true
+        ]
+
+        let flagPole = FlagPole(hoist: TestFlags.self, sources: [ source ])
+        XCTAssertTrue(flagPole.topLevelFlag)
+        XCTAssertFalse(flagPole.oneFlagGroup.secondLevelFlag)
+    }
+
+
+    // MARK: - Writing Values
+
+    func testWritesValues () {
+        AssertNoThrow {
+            let source = FlagValueDictionary()
+            let flagPole = FlagPole(hoist: TestFlags.self, sources: [ source ])
+
+            let snapshot = flagPole.emptySnapshot()
+            snapshot.topLevelFlag = true
+            snapshot.oneFlagGroup.secondLevelFlag = false
+            try flagPole.save(snapshot: snapshot, to: source)
+
+            XCTAssertEqual(source.storage["top-level-flag"] as? Bool, true)
+            XCTAssertEqual(source.storage["one-flag-group.second-level-flag"] as? Bool, false)
+        }
+    }
+
+
+    // MARK: - Publishing Tests
+
+    #if !os(Linux)
+
+    func testPublishesValues () {
+        let expectation = self.expectation(description: "publisher")
+
+        let source = FlagValueDictionary()
+        let flagPole = FlagPole(hoist: TestFlags.self, sources: [ source ])
+
+        var snapshots = [Snapshot<TestFlags>]()
+        let cancellable = flagPole.publisher
+            .sink { snapshot in
+                snapshots.append(snapshot)
+                if snapshots.count == 3 {
+                    expectation.fulfill()
+                }
+            }
+
+        source["top-level-flag"] = true
+        source["one-flag-group.second-level-flag"] = true
+
+        self.wait(for: [ expectation ], timeout: 1)
+
+        XCTAssertNotNil(cancellable)
+        XCTAssertEqual(snapshots.count, 3)
+        XCTAssertEqual(snapshots[safe: 0]?.topLevelFlag, false)
+        XCTAssertEqual(snapshots[safe: 0]?.oneFlagGroup.secondLevelFlag, false)
+        XCTAssertEqual(snapshots[safe: 1]?.topLevelFlag, true)
+        XCTAssertEqual(snapshots[safe: 1]?.oneFlagGroup.secondLevelFlag, false)
+        XCTAssertEqual(snapshots[safe: 2]?.topLevelFlag, true)
+        XCTAssertEqual(snapshots[safe: 2]?.oneFlagGroup.secondLevelFlag, true)
+    }
+
+    #endif
+
+}
+
+
+// MARK: - Fixtures
+
+// swiftlint:disable let_var_whitespace
+
+private struct TestFlags: FlagContainer {
+
+    @FlagGroup(description: "Test 1")
+    var oneFlagGroup: OneFlags
+
+    @Flag(default: false, description: "Top level test flag")
+    var topLevelFlag: Bool
+
+}
+
+private struct OneFlags: FlagContainer {
+
+    @Flag(default: false, description: "Second level test flag")
+    var secondLevelFlag: Bool
+}

--- a/Tests/VexilTests/TestHelpers.swift
+++ b/Tests/VexilTests/TestHelpers.swift
@@ -27,3 +27,10 @@ public func AssertThrows (file: StaticString = #file, line: UInt = #line, _ expr
     }
     return result
 }
+
+extension Collection {
+    subscript(safe index: Index) -> Element? {
+        guard index < self.endIndex else { return nil }
+        return self[index]
+    }
+}


### PR DESCRIPTION
Added a very simple `FlagValueDictionary` type that wraps a dictionary and can be used as a `FlagValueSource`. This is mostly useful for testing, but I'm sure there are other simple use cases out there.