### PR TITLE
Removed the explicit products as they seem to crash Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,14 +17,6 @@ let package = Package(
         // Automatic
         .library(name: "Vexil", targets: [ "Vexil" ]),
         .library(name: "Vexillographer", targets: [ "Vexillographer" ]),
-
-        // Static
-        .library(name: "Vexil-static", type: .static, targets: [ "Vexil" ]),
-        .library(name: "Vexillographer-static", type: .static, targets: [ "Vexil", "Vexillographer" ]),
-
-        // Dynamic
-        .library(name: "Vexil-dynamic", type: .dynamic, targets: [ "Vexil" ]),
-        .library(name: "Vexillographer-dynamic", type: .dynamic, targets: [ "Vexillographer" ]),
     ],
 
     dependencies: [


### PR DESCRIPTION
### 📒 Description

Removed the explicit products in the `Package.swift` as they seem to be causing Xcode 12 to crash.