### PR TITLE
Updated support for Swift 5.3, iOS 14 and macOS 11

### DIFF
--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -25,14 +25,50 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
     var body: some View {
         VStack {
             HStack {
-                Picker(self.label, selection: self.$flagValue) {
-                    ForEach(Value.allCases, id: \.self) { value in
-                        FlagDisplayValueView(value: value)
+                NavigationLink(destination: self.selector, isActive: self.$showPicker) {
+                    HStack {
+                        Text(self.label).font(.headline)
+                        Spacer()
+                        FlagDisplayValueView(value: self.flagValue)
                     }
                 }
                 DetailButton(showDetail: self.$showDetail)
             }
         }
+    }
+
+    #if os(iOS)
+
+    var selector: some View {
+        return self.selectorList
+            .navigationBarTitle(Text(self.label), displayMode: .inline)
+    }
+
+    #else
+
+    var selector: some View {
+        return self.selectorList
+    }
+
+    #endif
+
+    var selectorList: some View {
+        List(Value.allCases, id: \.self, selection: Binding(self.$flagValue)) { value in
+            HStack {
+                FlagDisplayValueView(value: value)
+                Spacer()
+
+                if value == self.flagValue {
+                    Image(systemName: "checkmark")
+                }
+            }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    self.flagValue = value
+                    self.showPicker = false
+                }
+        }
+            .listStyle(GroupedListStyle())
     }
 
 }

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -41,6 +41,7 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
 
     var selector: some View {
         return self.selectorList
+            .listStyle(GroupedListStyle())
             .navigationBarTitle(Text(self.label), displayMode: .inline)
     }
 
@@ -59,7 +60,11 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
                 Spacer()
 
                 if value == self.flagValue {
-                    Image(systemName: "checkmark")
+                    if #available(OSX 11.0, *) {
+                        Image(systemName: "checkmark")
+                    } else {
+                        Text("✓")
+                    }
                 }
             }
                 .contentShape(Rectangle())
@@ -68,7 +73,6 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
                     self.showPicker = false
                 }
         }
-            .listStyle(GroupedListStyle())
     }
 
 }

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -60,11 +60,7 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
                 Spacer()
 
                 if value == self.flagValue {
-                    if #available(OSX 11.0, *) {
-                        Image(systemName: "checkmark")
-                    } else {
-                        Text("✓")
-                    }
+                    self.checkmark
                 }
             }
                 .contentShape(Rectangle())
@@ -74,6 +70,30 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
                 }
         }
     }
+
+    #if swift(>=5.3)
+
+    var checkmark: some View {
+        if #available(OSX 11.0, *) {
+            return Image(systemName: "checkmark").eraseToAnyView()
+        } else {
+            return Text("✓").eraseToAnyView()
+        }
+    }
+
+    #else
+
+    #if os(macOS)
+    var checkmark: some View {
+        return Text("✓")
+    }
+    #else
+    var checkmark: some View {
+        return Image(systemName: "checkmark")
+    }
+    #endif
+
+    #endif
 
 }
 

--- a/Tests/VexilTests/FlagValueBoxingTests.swift
+++ b/Tests/VexilTests/FlagValueBoxingTests.swift
@@ -212,9 +212,15 @@ final class FlagValueBoxingTests: XCTestCase {
         }
 
         struct TestStruct: Codable, FlagValue, Equatable {
-            let property1 = 123
-            let property2 = "456"
-            let property3 = 789.0
+            let property1: Int
+            let property2: String
+            let property3: Double
+
+            init () {
+                self.property1 = 123
+                self.property2 = "456"
+                self.property3 = 789.0
+            }
         }
     }
 }

--- a/Tests/VexilTests/FlagValueCompilationTests.swift
+++ b/Tests/VexilTests/FlagValueCompilationTests.swift
@@ -187,9 +187,15 @@ final class FlagValueCompilationTests: XCTestCase {
         XCTAssertEqual(pole.flag, value)
 
         struct TestStruct: Codable, FlagValue, Equatable {
-            let property1 = 123
-            let property2 = "456"
-            let property3 = 789.0
+            let property1: Int
+            let property2: String
+            let property3: Double
+
+            init () {
+                self.property1 = 123
+                self.property2 = "456"
+                self.property3 = 789.0
+            }
         }
     }
 

--- a/Tests/VexilTests/FlagValueUnboxingTests.swift
+++ b/Tests/VexilTests/FlagValueUnboxingTests.swift
@@ -266,9 +266,15 @@ final class FlagValueUnboxingTests: XCTestCase {
         }
 
         struct TestStruct: Codable, FlagValue, Equatable {
-            let property1 = 123
-            let property2 = "456"
-            let property3 = 789.0
+            let property1: Int
+            let property2: String
+            let property3: Double
+
+            init () {
+                self.property1 = 123
+                self.property2 = "456"
+                self.property3 = 789.0
+            }
         }
     }
 }

--- a/Tests/VexilTests/TestHelpers.swift
+++ b/Tests/VexilTests/TestHelpers.swift
@@ -7,6 +7,31 @@
 
 import XCTest
 
+#if compiler(>=5.3)
+
+public func AssertNoThrow (file: StaticString = #filePath, line: UInt = #line, _ expression: () throws -> Void) {
+    XCTAssertNoThrow(try expression(), file: file, line: line)
+}
+
+public func AssertThrows<E> (error: E, file: StaticString = #filePath, line: UInt = #line, _ expression: () throws -> Void) where E: Equatable {
+    var result: E?
+    XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError in
+        result = thrownError as? E
+    }
+    XCTAssertEqual(result, error)
+}
+
+@discardableResult
+public func AssertThrows (file: StaticString = #filePath, line: UInt = #line, _ expression: () throws -> Void) -> Swift.Error? {
+    var result: Swift.Error?
+    XCTAssertThrowsError(try expression(), file: file, line: line) { thrownError in
+        result = thrownError
+    }
+    return result
+}
+
+#else
+
 public func AssertNoThrow (file: StaticString = #file, line: UInt = #line, _ expression: () throws -> Void) {
     XCTAssertNoThrow(try expression(), file: file, line: line)
 }
@@ -27,6 +52,8 @@ public func AssertThrows (file: StaticString = #file, line: UInt = #line, _ expr
     }
     return result
 }
+
+#endif
 
 extension Collection {
     subscript(safe index: Index) -> Element? {

--- a/Tests/VexilTests/UserDefaultsDecodingTests.swift
+++ b/Tests/VexilTests/UserDefaultsDecodingTests.swift
@@ -245,9 +245,15 @@ final class UserDefaultsDecodingTests: XCTestCase {
 
     func testDecodeCodable () {
         struct MyStruct: FlagValue, Codable, Equatable {
-            let property1 = "value1"
-            let property2 = 123
-            let property3 = "🤯"
+            let property1: String
+            let property2: Int
+            let property3: String
+
+            init () {
+                self.property1 = "value1"
+                self.property2 = 123
+                self.property3 = "🤯"
+            }
         }
 
         let expected = MyStruct()

--- a/Tests/VexilTests/UserDefaultsEncodingTests.swift
+++ b/Tests/VexilTests/UserDefaultsEncodingTests.swift
@@ -279,9 +279,15 @@ final class UserDefaultsEncodingTests: XCTestCase {
 
     func testEncodeCodable () {
         struct MyStruct: FlagValue, Codable, Equatable {
-            let property1 = "value1"
-            let property2 = 123
-            let property3 = "🤯"
+            let property1: String
+            let property2: Int
+            let property3: String
+
+            init () {
+                self.property1 = "value1"
+                self.property2 = 123
+                self.property3 = "🤯"
+            }
         }
 
         let input = MyStruct()


### PR DESCRIPTION
This includes:

- Changing the way we do the picker in Vexillographer to be more manual (menus are better than wheels!)
- Using `#filePath` where appropriate
- Fixing the initialisers for our `Decodable`-based tests
