### PR TITLE
The UserDefaults FlagValueSource now emits when the application re-opens

### DIFF
--- a/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
@@ -42,7 +42,7 @@ extension UserDefaults: FlagValueSource {
 
     }
 
-    #if !os(Linux)
+    #if os(watchOS)
 
     /// A Publisher that emits events when the flag values it manages changes
     public var valuesDidChange: AnyPublisher<Void, Never>? {
@@ -51,5 +51,32 @@ extension UserDefaults: FlagValueSource {
             .eraseToAnyPublisher()
     }
 
+    #elseif !os(Linux)
+
+    public var valuesDidChange: AnyPublisher<Void, Never>? {
+        return Publishers.Merge (
+            NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification).map { _ in () },
+            NotificationCenter.default.publisher(for: ApplicationDidBecomeActive).map { _ in () }
+        )
+            .eraseToAnyPublisher()
+    }
+
     #endif
 }
+
+
+// MARK: - Application Active Notifications
+
+#if canImport(UIKit)
+
+import UIKit
+
+private let ApplicationDidBecomeActive = UIApplication.didBecomeActiveNotification
+
+#elseif canImport(Cocoa)
+
+import Cocoa
+
+private let ApplicationDidBecomeActive = NSApplication.didBecomeActiveNotification
+
+#endif


### PR DESCRIPTION
### 📒 Description

This is to work around this limitation:

>NSUserDefaultsDidChangeNotification is posted whenever any user defaults changed within the current process, but is not posted when ubiquitous defaults change, or when an outside process changes defaults. Using key-value observing to register observers for the specific keys of interest will inform you of all updates, regardless of where they're from.

This means changes made in a separate app using App Groups or similar will now be applied when the app re-opens