### PR TITLE
Added additional unit test CI jobs for all supported platforms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,39 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Build and Test
         run: swift test
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_11.5.app/Contents/Developer
+  
+  test-ios:
+    name: iOS
+    runs-on: macOS-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
+
+  test-tvos:
+    name: tvOS
+    runs-on: macOS-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=tvOS Simulator,name=Apple TV 4K"
+
+  build-watchOS:
+    name: watchOS (Build Only)
+    runs-on: macOS-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift package generate-xcodeproj && xcrun xcodebuild build -scheme "Vexil-Package" -destination "generic/platform=watchos"
 
   test-linux:
     name: Linux

--- a/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
@@ -67,7 +67,7 @@ extension UserDefaults: FlagValueSource {
 
 // MARK: - Application Active Notifications
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 
 import UIKit
 


### PR DESCRIPTION
We now have unit test CI jobs for:

- macOS
- iOS
- tvOS
- watchOS (build only)
- Linux