### PR TITLE
Hide flags from Vexillographer that aren't supported for editing

### DIFF
--- a/.github/workflows/documentation-coverage.yml
+++ b/.github/workflows/documentation-coverage.yml
@@ -13,7 +13,7 @@ on:
       - '**/*.swift'
 
 env:
-  SWIFT_DOC_VERSION: 1.0.0-beta.4
+  SWIFT_DOC_VERSION: master
 
 jobs:
   CheckDocumentation:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+/Release

--- a/Sources/Vexillographer/Unfurling/Unfurlable.swift
+++ b/Sources/Vexillographer/Unfurling/Unfurlable.swift
@@ -25,7 +25,8 @@ extension Flag: Unfurlable where Value: FlagValue {
     ///
     func unfurl<RootGroup> (label: String, manager: FlagValueManager<RootGroup>) -> UnfurledFlagItem? where RootGroup: FlagContainer {
         guard self.info.shouldDisplay == true else { return nil }
-        return UnfurledFlag(name: self.info.name ?? label.localizedDisplayName, flag: self, manager: manager)
+        let unfurled = UnfurledFlag(name: self.info.name ?? label.localizedDisplayName, flag: self, manager: manager)
+        return unfurled.isEditable ? unfurled : nil
     }
 }
 
@@ -35,7 +36,8 @@ extension FlagGroup: Unfurlable {
     ///
     func unfurl<RootGroup>(label: String, manager: FlagValueManager<RootGroup>) -> UnfurledFlagItem? where RootGroup: FlagContainer {
         guard self.info.shouldDisplay == true else { return nil }
-        return UnfurledFlagGroup(name: self.info.name ?? label.localizedDisplayName, group: self, manager: manager)
+        let unfurled = UnfurledFlagGroup(name: self.info.name ?? label.localizedDisplayName, group: self, manager: manager)
+        return unfurled.isEditable ? unfurled : nil
     }
 }
 

--- a/Sources/Vexillographer/Unfurling/UnfurledFlag.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlag.swift
@@ -25,6 +25,10 @@ struct UnfurledFlag<Value, RootGroup>: UnfurledFlagItem, Identifiable where Valu
         return self.flag.id
     }
 
+    var isEditable: Bool {
+        return self is BooleanEditableFlag || self is CaseIterableEditableFlag || self is StringEditableFlag
+    }
+
 
     // MARK: - Initialisation
 

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
@@ -25,6 +25,11 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
         return self.group.id
     }
 
+    var isEditable: Bool {
+        return self.allItems()
+            .isEmpty == false
+    }
+
 
     // MARK: - Initialisation
 
@@ -42,7 +47,8 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
             .children
             .compactMap { child -> UnfurledFlagItem? in
                 guard let label = child.label, let unfurlable = child.value as? Unfurlable else { return nil }
-                return unfurlable.unfurl(label: label, manager: self.manager)
+                guard let unfurled = unfurlable.unfurl(label: label, manager: self.manager) else { return nil }
+                return unfurled.isEditable ? unfurled : nil
             }
     }
 
@@ -54,12 +60,6 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
             }
         }
             .eraseToAnyView()
-    }
-}
-
-struct UnfurledFlagGroup_Previews: PreviewProvider {
-    static var previews: some View {
-        /*@START_MENU_TOKEN@*/Text("Hello, World!")/*@END_MENU_TOKEN@*/
     }
 }
 

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
@@ -16,6 +16,7 @@ protocol UnfurledFlagItem {
     var info: UnfurledFlagInfo { get }
     var hasChildren: Bool { get }
     var unfurledView: AnyView { get }
+    var isEditable: Bool { get }
 }
 
 #endif


### PR DESCRIPTION
### 📒 Description

We don't currently support editing for all possible flag values, and probably never well (Codable types), so we should hide these from Vexillographer instead of displaying a blank row.
