### PR TITLE
Added support for displaying FlagGroups as Sections in Vexillographer

### DIFF
--- a/Sources/Vexil/Group.swift
+++ b/Sources/Vexil/Group.swift
@@ -26,6 +26,9 @@ public struct FlagGroup<Group>: Decorated, Identifiable where Group: FlagContain
     /// The `FlagContainer` being wrapped.
     public var wrappedValue: Group
 
+    /// How we should display this group in Vexillographer
+    public let display: Display
+
 
     // MARK: - Initialisation
 
@@ -42,10 +45,12 @@ public struct FlagGroup<Group>: Decorated, Identifiable where Group: FlagContain
     ///   - codingKeyStragey:   An optional strategy to use when calculating the key name for this group. The default is to use the `FlagPole`s strategy.
     ///   - description:        A description of this flag group. Used in flag editors like Vexillographer and also for future developer context.
     ///                         You can also specify `.hidden` to hide this flag group from Vexillographer.
+    ///   - display:            Whether we should display this FlagGroup as using a `NavigationLink` or as a `Section` in Vexillographer
     ///
-    public init (name: String? = nil, codingKeyStrategy: CodingKeyStrategy = .default, description: FlagInfo) {
+    public init (name: String? = nil, codingKeyStrategy: CodingKeyStrategy = .default, description: FlagInfo, display: Display = .navigation) {
         self.codingKeyStrategy = codingKeyStrategy
         self.wrappedValue = Group()
+        self.display = display
 
         var info = description
         info.name = name
@@ -95,4 +100,31 @@ public struct FlagGroup<Group>: Decorated, Identifiable where Group: FlagContain
                 $0.value.decorate(lookup: lookup, label: $0.label, codingPath: codingPath, config: config)
             }
     }
+}
+
+
+// MARK: - Group Display
+
+public extension FlagGroup {
+
+    /// How to display this group in Vexillographer
+    ///
+    enum Display {
+
+        /// Displays this group using a `NavigationLink`. This is the default.
+        ///
+        /// In the navigated view the `name` is the cell's display name and the navigated view's
+        /// title, and the `description` is displayed at the top of the navigated view.
+        ///
+        case navigation
+
+        /// Displays this group using a `Section`
+        ///
+        /// The `name` of this FlagGroup is used as the Section's header, and the `description`
+        /// as the Section's footer.
+        ///
+        case section
+
+    }
+
 }

--- a/Sources/Vexillographer/FlagSectionView.swift
+++ b/Sources/Vexillographer/FlagSectionView.swift
@@ -1,0 +1,59 @@
+//
+//  FlagSectionView.swift
+//  Vexil: Vexillographer
+//
+//  Created by Rob Amos on 4/10/20.
+//
+
+#if os(iOS) || os(macOS)
+
+import SwiftUI
+import Vexil
+
+struct UnfurledFlagSectionView<Group, Root>: View where Group: FlagContainer, Root: FlagContainer {
+
+    // MARK: - Properties
+
+    let group: UnfurledFlagGroup<Group, Root>
+    @ObservedObject var manager: FlagValueManager<Root>
+
+
+    // MARK: - Initialisation
+
+    init (group: UnfurledFlagGroup<Group, Root>, manager: FlagValueManager<Root>) {
+        self.group = group
+        self.manager = manager
+    }
+
+
+    // MARK: - View Body
+
+    #if os(iOS)
+
+    var body: some View {
+        self.content
+            .navigationBarTitle(Text(self.group.info.name), displayMode: .inline)
+    }
+
+    #else
+
+    var body: some View {
+        self.content
+    }
+
+    #endif
+
+    var content: some View {
+        Section (
+            header: Text(self.group.info.name),
+            footer: Text(self.group.info.description),
+            content: {
+                ForEach(self.group.allItems(), id: \.id) { item in
+                    item.unfurledView
+                }
+            }
+        )
+    }
+}
+
+#endif

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
@@ -53,13 +53,20 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
     }
 
     var unfurledView: AnyView {
-        return NavigationLink(destination: UnfurledFlagGroupView(group: self, manager: self.manager)) {
-            HStack {
-                Text(self.info.name)
-                    .font(.headline)
+        switch self.group.display {
+        case .navigation:
+            return NavigationLink(destination: UnfurledFlagGroupView(group: self, manager: self.manager)) {
+                HStack {
+                    Text(self.info.name)
+                        .font(.headline)
+                }
             }
+                .eraseToAnyView()
+
+        case .section:
+            return UnfurledFlagSectionView(group: self, manager: self.manager)
+                .eraseToAnyView()
         }
-            .eraseToAnyView()
     }
 }
 


### PR DESCRIPTION
### 📒 Description

FlagGroups now have an additional parameter during initialisation to describe how it should be displayed in Vexillographer.

It has two options:

- `.navigation`: Displays the FlagGroup's contents using a `NavigationLink`. This is the default and matches the existing behaviour.
- `.section`: Displays the FlagGroup's contents inside a `Section`.