### PR TITLE
Highlighted flags in Vexillographer that have overridden values.

### DIFF
--- a/Sources/Vexillographer/DetailButton.swift
+++ b/Sources/Vexillographer/DetailButton.swift
@@ -13,6 +13,7 @@ struct DetailButton: View {
 
     // MARK: - Properties
 
+    let hasChanges: Bool
     @Binding var showDetail: Bool
 
 
@@ -23,7 +24,7 @@ struct DetailButton: View {
     var body: some View {
         Button (
             action: {},
-            label: { Image(systemName: "info.circle") }
+            label: { Image(systemName: self.hasChanges ? "info.circle.fill" : "info.circle") }
         )
             .onTapGesture { self.showDetail.toggle() }
     }

--- a/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
@@ -25,6 +25,8 @@ struct BooleanFlagControl: View {
 
     let label: String
     @Binding var value: Bool
+
+    let hasChanges: Bool
     @Binding var showDetail: Bool
 
 
@@ -33,7 +35,7 @@ struct BooleanFlagControl: View {
     var body: some View {
         HStack {
             Toggle(self.label, isOn: self.$value)
-            DetailButton(showDetail: self.$showDetail)
+            DetailButton(hasChanges: self.hasChanges, showDetail: self.$showDetail)
         }
     }
 }
@@ -57,6 +59,7 @@ extension UnfurledFlag: BooleanEditableFlag where Value.BoxedValueType == Bool {
                 defaultValue: self.flag.defaultValue,
                 transformer: BoxedPassthroughTransformer.self
             ),
+            hasChanges: manager.hasValueInSource(flag: self.flag),
             showDetail: showDetail
         )
             .eraseToAnyView()
@@ -81,6 +84,7 @@ extension UnfurledFlag: OptionalBooleanEditableFlag where Value: FlagValue, Valu
                 defaultValue: self.flag.defaultValue,
                 transformer: OptionalTransformer<Value.BoxedValueType, Bool, BoxedPassthroughTransformer>.self
             ),
+            hasChanges: manager.hasValueInSource(flag: self.flag),
             showDetail: showDetail
         )
             .eraseToAnyView()

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -20,6 +20,8 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
 
     let label: String
     @Binding var value: Value
+
+    let hasChanges: Bool
     @Binding var showDetail: Bool
 
     @State private var showPicker = false
@@ -36,7 +38,7 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
                         FlagDisplayValueView(value: self.value)
                     }
                 }
-                DetailButton(showDetail: self.$showDetail)
+                DetailButton(hasChanges: self.hasChanges, showDetail: self.$showDetail)
             }
         }
     }
@@ -110,6 +112,7 @@ extension UnfurledFlag: CaseIterableEditableFlag
                 defaultValue: self.flag.defaultValue,
                 transformer: PassthroughTransformer<Value>.self
             ),
+            hasChanges: manager.hasValueInSource(flag: self.flag),
             showDetail: showDetail
         )
             .eraseToAnyView()

--- a/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
@@ -23,6 +23,8 @@ struct OptionalCaseIterableFlagControl<Value>: View
 
     let label: String
     @Binding var value: Value
+
+    let hasChanges: Bool
     @Binding var showDetail: Bool
 
     @State private var showPicker = false
@@ -39,7 +41,7 @@ struct OptionalCaseIterableFlagControl<Value>: View
                         FlagDisplayValueView(value: self.value.wrapped)
                     }
                 }
-                DetailButton(showDetail: self.$showDetail)
+                DetailButton(hasChanges: self.hasChanges, showDetail: self.$showDetail)
             }
         }
     }
@@ -139,6 +141,7 @@ extension UnfurledFlag: OptionalCaseIterableEditableFlag
                     }
                 }
             ),
+            hasChanges: manager.hasValueInSource(flag: self.flag),
             showDetail: showDetail
         )
             .eraseToAnyView()

--- a/Sources/Vexillographer/Flag Value Controls/StringFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/StringFlagControl.swift
@@ -20,6 +20,8 @@ struct StringFlagControl: View {
 
     let label: String
     @Binding var value: String
+
+    let hasChanges: Bool
     @Binding var showDetail: Bool
 
 
@@ -31,7 +33,7 @@ struct StringFlagControl: View {
             Spacer()
             TextField("", text: self.$value)
                 .multilineTextAlignment(.trailing)
-            DetailButton(showDetail: self.$showDetail)
+            DetailButton(hasChanges: self.hasChanges, showDetail: self.$showDetail)
         }
     }
 }
@@ -54,6 +56,7 @@ extension UnfurledFlag: StringEditableFlag where Value.BoxedValueType: LosslessS
                 defaultValue: self.flag.defaultValue,
                 transformer: LosslessStringTransformer<Value.BoxedValueType>.self
             ),
+            hasChanges: manager.hasValueInSource(flag: self.flag),
             showDetail: showDetail
         )
             .flagValueKeyboard(type: Value.self)
@@ -81,6 +84,7 @@ extension UnfurledFlag: OptionalStringEditableFlag
                 defaultValue: self.flag.defaultValue,
                 transformer: OptionalTransformer<Value.BoxedValueType, String, LosslessStringTransformer<Value.BoxedValueType.WrappedFlagValue>>.self
             ),
+            hasChanges: manager.hasValueInSource(flag: self.flag),
             showDetail: showDetail
         )
             .flagValueKeyboard(type: Value.self)

--- a/Sources/Vexillographer/FlagValueManager.swift
+++ b/Sources/Vexillographer/FlagValueManager.swift
@@ -54,6 +54,15 @@ class FlagValueManager<RootGroup>: ObservableObject where RootGroup: FlagContain
         try self.flagPole.save(snapshot: snapshot, to: self.source)
     }
 
+    func hasValueInSource<Value> (flag: Flag<Value>) -> Bool {
+        if let _: Value = self.source.flagValue(key: flag.key) {
+            return true
+
+        } else {
+            return false
+        }
+    }
+
 
     // MARK: - Boxed Values
 


### PR DESCRIPTION
### 📒 Description

If a Flag has an overridden value it will now display with `info.circle.fill` instead of `info.circle` (ie a filled circle instead of a regular one)