### PR TITLE
Vexillographer Mac UI Uplift

### DIFF
--- a/Sources/Vexillographer/Bindings/Binding.swift
+++ b/Sources/Vexillographer/Bindings/Binding.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import Vexil
 
 extension Binding {
+    @available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
     init<Transformer, RootGroup, FValue> (key: String, manager: FlagValueManager<RootGroup>, defaultValue: FValue, transformer: Transformer.Type) where RootGroup: FlagContainer, Transformer: BoxedFlagValueTransformer, FValue: FlagValue, Transformer.EditingValue == Value, FValue.BoxedValueType == Transformer.OriginalValue {
         self.init (
             get: {
@@ -29,6 +30,7 @@ extension Binding {
         )
     }
 
+    @available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
     init<Transformer, RootGroup> (key: String, manager: FlagValueManager<RootGroup>, defaultValue: Transformer.OriginalValue, transformer: Transformer.Type) where RootGroup: FlagContainer, Transformer: FlagValueTransformer, Transformer.EditingValue == Value {
         self.init (
             get: {

--- a/Sources/Vexillographer/DetailButton.swift
+++ b/Sources/Vexillographer/DetailButton.swift
@@ -9,6 +9,7 @@
 
 import SwiftUI
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct DetailButton: View {
 
     // MARK: - Properties

--- a/Sources/Vexillographer/Extensions/NSApplication+Sidebar.swift
+++ b/Sources/Vexillographer/Extensions/NSApplication+Sidebar.swift
@@ -1,0 +1,18 @@
+//
+//  NSApplication+Sidebar.swift
+//  Vexil: Vexilographer
+//
+
+#if os(macOS)
+
+import AppKit
+
+extension NSApplication {
+    
+    func toggleKeyWindowSidebar() {
+        self.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
+    }
+    
+}
+
+#endif

--- a/Sources/Vexillographer/Extensions/NSApplication+Sidebar.swift
+++ b/Sources/Vexillographer/Extensions/NSApplication+Sidebar.swift
@@ -8,11 +8,11 @@
 import AppKit
 
 extension NSApplication {
-    
+
     func toggleKeyWindowSidebar() {
         self.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
     }
-    
+
 }
 
 #endif

--- a/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
@@ -19,6 +19,7 @@ import Vexil
 //
 // Plus any custom types that are boxed to a Bool.
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct BooleanFlagControl: View {
 
     // MARK: - Properties
@@ -45,10 +46,12 @@ struct BooleanFlagControl: View {
 
 /// Support for `UnfurledFlag` when `FlagValue.BoxedValueType == Bool`
 ///
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 protocol BooleanEditableFlag {
     func control<RootGroup> (label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer
 }
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 extension UnfurledFlag: BooleanEditableFlag where Value.BoxedValueType == Bool {
     func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer {
         return BooleanFlagControl (
@@ -70,10 +73,12 @@ extension UnfurledFlag: BooleanEditableFlag where Value.BoxedValueType == Bool {
 
 /// Support for `UnfurledFlag` when `FlagValue.BoxedFlagValue == Bool?`
 ///
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 protocol OptionalBooleanEditableFlag {
     func control<RootGroup> (label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer
 }
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 extension UnfurledFlag: OptionalBooleanEditableFlag where Value: FlagValue, Value.BoxedValueType: OptionalFlagValue, Value.BoxedValueType.WrappedFlagValue == Bool {
     func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer {
         return BooleanFlagControl (

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -14,6 +14,7 @@ import Vexil
 //
 // Case Iterable flags are those those whose flag value conforms to `CaseIterable`
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseIterable, Value: Hashable, Value.AllCases: RandomAccessCollection {
 
     // MARK: - Properties
@@ -27,6 +28,8 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
     @State private var showPicker = false
 
     // MARK: - View Body
+
+    #if os(iOS)
 
     var body: some View {
         VStack {
@@ -43,18 +46,27 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
         }
     }
 
-    #if os(iOS)
-
     var selector: some View {
         return self.selectorList
             .listStyle(GroupedListStyle())
             .navigationBarTitle(Text(self.label), displayMode: .inline)
     }
 
-    #else
+    #elseif os(macOS)
 
-    var selector: some View {
-        return self.selectorList
+    var body: some View {
+        HStack {
+            Picker (
+                selection: self.$value,
+                label: Text(self.label),
+                content: {
+                    ForEach(Value.allCases, id: \.self) { value in
+                        FlagDisplayValueView(value: value)
+                    }
+                }
+            )
+                .pickerStyle(MenuPickerStyle())
+        }
     }
 
     #endif
@@ -96,10 +108,12 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
 
 // MARK: - Creating CaseIterableFlagControls
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 protocol CaseIterableEditableFlag {
     func control<RootGroup> (label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer
 }
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 extension UnfurledFlag: CaseIterableEditableFlag
             where Value: FlagValue, Value: CaseIterable, Value.AllCases: RandomAccessCollection,
                   Value: RawRepresentable, Value.RawValue: FlagValue, Value: Hashable {

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -55,18 +55,26 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
     #elseif os(macOS)
 
     var body: some View {
-        HStack {
-            Picker (
-                selection: self.$value,
-                label: Text(self.label),
-                content: {
-                    ForEach(Value.allCases, id: \.self) { value in
-                        FlagDisplayValueView(value: value)
-                    }
+        let picker = Picker (
+            selection: self.$value,
+            label: Text(self.label),
+            content: {
+                ForEach(Value.allCases, id: \.self) { value in
+                    FlagDisplayValueView(value: value)
                 }
-            )
-                .pickerStyle(MenuPickerStyle())
-        }
+            }
+        )
+
+        #if compiler(>=5.3)
+
+        return picker
+            .pickerStyle(MenuPickerStyle())
+
+        #else
+
+        return picker
+
+        #endif
     }
 
     #endif

--- a/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
@@ -14,7 +14,7 @@ import Vexil
 //
 // For those whose flag value is optional and conform to `CaseIterable`
 
-
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct OptionalCaseIterableFlagControl<Value>: View
             where Value: OptionalFlagValue, Value.WrappedFlagValue: CaseIterable,
                   Value.WrappedFlagValue: Hashable, Value.WrappedFlagValue.AllCases: RandomAccessCollection {
@@ -117,10 +117,12 @@ struct OptionalCaseIterableFlagControl<Value>: View
 
 // MARK: - Creating CaseIterableFlagControls
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 protocol OptionalCaseIterableEditableFlag {
     func control<RootGroup> (label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer
 }
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 extension UnfurledFlag: OptionalCaseIterableEditableFlag
                 where Value: OptionalFlagValue, Value.WrappedFlagValue: CaseIterable,
                       Value.WrappedFlagValue.AllCases: RandomAccessCollection, Value.WrappedFlagValue: RawRepresentable,

--- a/Sources/Vexillographer/Flag Value Controls/StringFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/StringFlagControl.swift
@@ -14,6 +14,7 @@ import Vexil
 //
 // String flag values are ones whose flag value conforms to `LosslessStringConvertible`
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct StringFlagControl: View {
 
     // MARK: - Properties
@@ -41,10 +42,12 @@ struct StringFlagControl: View {
 
 // MARK: - Lossless String Convertible Flags
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 protocol StringEditableFlag {
     func control<RootGroup> (label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer
 }
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 extension UnfurledFlag: StringEditableFlag where Value.BoxedValueType: LosslessStringConvertible {
 
     func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer {
@@ -68,10 +71,12 @@ extension UnfurledFlag: StringEditableFlag where Value.BoxedValueType: LosslessS
 
 // MARK: - Optional Lossless String Convertible Flags
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 protocol OptionalStringEditableFlag {
     func control<RootGroup> (label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer
 }
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 extension UnfurledFlag: OptionalStringEditableFlag
         where Value: FlagValue, Value.BoxedValueType: OptionalFlagValue, Value.BoxedValueType.WrappedFlagValue: LosslessStringConvertible {
 

--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup: FlagContainer {
 
     // MARK: - Properties

--- a/Sources/Vexillographer/FlagDisplayValueView.swift
+++ b/Sources/Vexillographer/FlagDisplayValueView.swift
@@ -10,6 +10,7 @@
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct FlagDisplayValueView<Value>: View where Value: FlagValue {
 
     // MARK: - Properties

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -47,21 +47,16 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
     #elseif os(macOS)
 
     var body: some View {
-        VStack(alignment: .leading) {
-            self.description
-                .padding(.bottom, 8)
-            Divider()
-        }
-            .padding()
+        #if compiler(>=5.3)
 
-        Form {
-            Section {
-                self.flags
-            }
-        }
-            .padding([.leading, .trailing, .bottom], 30)
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
+        self.macBody
             .navigationTitle(self.group.info.name)
+
+        #else
+
+        self.macBody
+
+        #endif
     }
 
     #else
@@ -83,12 +78,14 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
             Text(self.group.info.description)
         }
             .contextMenu {
-                Button(action: self.group.info.description.copyToPasteboard) {
+                Button(action: self.group.info.description.copyToPasteboard) { () -> AnyView in
+                    #if compiler(>=5.3)
                     if #available(iOS 14, watchOS 7, tvOS 14, *) {
-                        Label("Copy", systemImage: "doc.on.doc")
-                    } else {
-                        Text("Copy")
+                        return Label("Copy", systemImage: "doc.on.doc").eraseToAnyView()
                     }
+                    #endif
+
+                    return Text("Copy").eraseToAnyView()
                 }
             }
     }
@@ -97,6 +94,23 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
         ForEach(self.group.allItems(), id: \.id) { item in
             item.unfurledView
         }
+    }
+
+    @ViewBuilder var macBody: some View {
+        VStack(alignment: .leading) {
+            self.description
+                .padding(.bottom, 8)
+            Divider()
+        }
+            .padding()
+
+        Form {
+            Section {
+                self.flags
+            }
+        }
+            .padding([.leading, .trailing, .bottom], 30)
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
     }
 
 }

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -52,7 +52,7 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
                 .padding(.bottom, 8)
             Divider()
         }.padding()
-        
+
         Form {
             Section {
                 self.flags
@@ -87,7 +87,7 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
                 }
             }
     }
-    
+
     var flags: some View {
         ForEach(self.group.allItems(), id: \.id) { item in
             item.unfurledView

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -51,7 +51,8 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
             self.description
                 .padding(.bottom, 8)
             Divider()
-        }.padding()
+        }
+            .padding()
 
         Form {
             Section {
@@ -82,8 +83,12 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
             Text(self.group.info.description)
         }
             .contextMenu {
-                Button(action: { self.group.info.description.copyToPasteboard() }) {
-                    Label("Copy", systemImage: "doc.on.doc")
+                Button(action: self.group.info.description.copyToPasteboard) {
+                    if #available(iOS 14, watchOS 7, tvOS 14, *) {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    } else {
+                        Text("Copy")
+                    }
                 }
             }
     }

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root: FlagContainer {
 
     // MARK: - Properties
@@ -35,6 +36,14 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
     var body: some View {
         self.content
             .navigationBarTitle(Text(self.group.info.name), displayMode: .inline)
+    }
+
+    #elseif os(macOS)
+
+    var body: some View {
+        self.content
+            .padding()
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
     }
 
     #else

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -5,8 +5,6 @@
 //  Created by Rob Amos on 16/6/20.
 //
 
-// swiftlint:disable multiple_closures_with_trailing_closure
-
 #if os(iOS) || os(macOS)
 
 import SwiftUI

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -49,12 +49,12 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
     var body: some View {
         #if compiler(>=5.3)
 
-        self.macBody
+        return self.macBody
             .navigationTitle(self.group.info.name)
 
         #else
 
-        self.macBody
+        return self.macBody
 
         #endif
     }

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -34,44 +34,66 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
     #if os(iOS)
 
     var body: some View {
-        self.content
+        Form {
+            self.description
+                .padding([.top, .bottom], 4)
+            Section(header: Text("Flags")) {
+                self.flags
+            }
+        }
             .navigationBarTitle(Text(self.group.info.name), displayMode: .inline)
     }
 
     #elseif os(macOS)
 
     var body: some View {
-        self.content
-            .padding()
+        VStack(alignment: .leading) {
+            self.description
+                .padding(.bottom, 8)
+            Divider()
+        }.padding()
+        
+        Form {
+            Section {
+                self.flags
+            }
+        }
+            .padding([.leading, .trailing, .bottom], 30)
             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
+            .navigationTitle(self.group.info.name)
     }
 
     #else
 
     var body: some View {
-        self.content
+        Form {
+            self.description
+            Section {
+                self.flags
+            }
+        }
     }
 
     #endif
 
-    var content: some View {
-        Form {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Description").font(.headline)
-                Text(self.group.info.description)
-            }
-                .contextMenu {
-                    Button(action: { self.group.info.description.copyToPasteboard() }) {
-                        Text("Copy description to clipboard")
-                    }
-                }
-            Section(header: Text("Flags")) {
-                ForEach(self.group.allItems(), id: \.id) { item in
-                    item.unfurledView
+    var description: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Description").font(.headline)
+            Text(self.group.info.description)
+        }
+            .contextMenu {
+                Button(action: { self.group.info.description.copyToPasteboard() }) {
+                    Label("Copy", systemImage: "doc.on.doc")
                 }
             }
+    }
+    
+    var flags: some View {
+        ForEach(self.group.allItems(), id: \.id) { item in
+            item.unfurledView
         }
     }
+
 }
 
 #endif

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -42,19 +42,24 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
             .navigationBarTitle(Text(self.group.info.name), displayMode: .inline)
     }
 
-    #elseif os(macOS)
+    #elseif os(macOS) && compiler(>=5.3)
 
     var body: some View {
-        #if compiler(>=5.3)
+        VStack(alignment: .leading) {
+            self.description
+                .padding(.bottom, 8)
+            Divider()
+        }
+            .padding()
 
-        return self.macBody
+        Form {
+            Section {
+                self.flags
+            }
+        }
+            .padding([.leading, .trailing, .bottom], 30)
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
             .navigationTitle(self.group.info.name)
-
-        #else
-
-        return self.macBody
-
-        #endif
     }
 
     #else
@@ -92,23 +97,6 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
         ForEach(self.group.allItems(), id: \.id) { item in
             item.unfurledView
         }
-    }
-
-    @ViewBuilder var macBody: some View {
-        VStack(alignment: .leading) {
-            self.description
-                .padding(.bottom, 8)
-            Divider()
-        }
-            .padding()
-
-        Form {
-            Section {
-                self.flags
-            }
-        }
-            .padding([.leading, .trailing, .bottom], 30)
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
     }
 
 }

--- a/Sources/Vexillographer/FlagSectionView.swift
+++ b/Sources/Vexillographer/FlagSectionView.swift
@@ -10,6 +10,7 @@
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct UnfurledFlagSectionView<Group, Root>: View where Group: FlagContainer, Root: FlagContainer {
 
     // MARK: - Properties

--- a/Sources/Vexillographer/FlagValueManager.swift
+++ b/Sources/Vexillographer/FlagValueManager.swift
@@ -12,6 +12,7 @@ import Foundation
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 class FlagValueManager<RootGroup>: ObservableObject where RootGroup: FlagContainer {
 
     // MARK: - Properties

--- a/Sources/Vexillographer/FlagView.swift
+++ b/Sources/Vexillographer/FlagView.swift
@@ -10,6 +10,7 @@
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct UnfurledFlagView<Value, RootGroup>: View where Value: FlagValue, RootGroup: FlagContainer {
 
     // MARK: - Properties

--- a/Sources/Vexillographer/Unfurling/Unfurlable.swift
+++ b/Sources/Vexillographer/Unfurling/Unfurlable.swift
@@ -15,10 +15,12 @@ import Vexil
 /// Basically this is used to provide the Flag and FlagGroups with a way to create a type-erased `UnfurledFlagItem`
 /// that describes themelves.
 ///
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 protocol Unfurlable {
     func unfurl<RootGroup> (label: String, manager: FlagValueManager<RootGroup>) -> UnfurledFlagItem? where RootGroup: FlagContainer
 }
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 extension Flag: Unfurlable where Value: FlagValue {
 
     /// Creates an `UnfurledFlag` from the receiver and returns it as a type-erased `UnfurledFlagItem`
@@ -30,6 +32,7 @@ extension Flag: Unfurlable where Value: FlagValue {
     }
 }
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 extension FlagGroup: Unfurlable {
 
     /// Creates an `UnfurledFlagGroup` from the receiver and returns it as a type-erased `UnfurledFlagItem`

--- a/Sources/Vexillographer/Unfurling/UnfurledFlag.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlag.swift
@@ -11,6 +11,7 @@ import Foundation
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct UnfurledFlag<Value, RootGroup>: UnfurledFlagItem, Identifiable where Value: FlagValue, RootGroup: FlagContainer {
 
     // MARK: - Properties
@@ -32,6 +33,10 @@ struct UnfurledFlag<Value, RootGroup>: UnfurledFlagItem, Identifiable where Valu
             || self is OptionalBooleanEditableFlag
             || self is OptionalCaseIterableEditableFlag
             || self is OptionalStringEditableFlag
+    }
+
+    var children: [UnfurledFlagItem]? {
+        return nil
     }
 
 

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
@@ -11,6 +11,7 @@ import Foundation
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Group: FlagContainer, Root: FlagContainer {
 
     // MARK: - Properties
@@ -30,6 +31,10 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
             .isEmpty == false
     }
 
+    var children: [UnfurledFlagItem]? {
+        let children = self.allItems().filter { $0.hasChildren == true }
+        return children.isEmpty == false ? children : nil
+    }
 
     // MARK: - Initialisation
 

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagInfo.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagInfo.swift
@@ -9,6 +9,7 @@
 
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 struct UnfurledFlagInfo {
 
     // MARK: - Properties

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
@@ -11,10 +11,12 @@ import Foundation
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 protocol UnfurledFlagItem {
     var id: UUID { get }
     var info: UnfurledFlagInfo { get }
     var hasChildren: Bool { get }
+    var children: [UnfurledFlagItem]? { get }
     var unfurledView: AnyView { get }
     var isEditable: Bool { get }
 }

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -34,6 +34,13 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
             item.unfurledView
         }
             .listStyle(SidebarListStyle())
+            .toolbar {
+                ToolbarItem(placement: .navigation) {
+                    Button(action: NSApp.toggleKeyWindowSidebar) {
+                        Image(systemName: "sidebar.left")
+                    }
+                }
+            }
     }
 
     #else

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -27,18 +27,13 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
 
     // MARK: - Body
 
-    #if os(macOS)
+    #if os(macOS) && compiler(>=5.3)
 
     public var body: some View {
-        let list = List(self.manager.allItems(), id: \.id, children: \.children) { item in
+        List(self.manager.allItems(), id: \.id, children: \.children) { item in
             item.unfurledView
         }
             .listStyle(SidebarListStyle())
-
-
-        #if compiler(>=5.3)
-
-        return list
             .toolbar {
                 ToolbarItem(placement: .navigation) {
                     Button(action: NSApp.toggleKeyWindowSidebar) {
@@ -46,12 +41,6 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
                     }
                 }
             }
-
-        #else
-
-        return list
-
-        #endif
     }
 
     #else

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -10,6 +10,7 @@
 import SwiftUI
 import Vexil
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
 
     // MARK: - Properties
@@ -26,12 +27,25 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
 
     // MARK: - Body
 
+    #if os(macOS)
+
+    public var body: some View {
+        List(self.manager.allItems(), id: \.id, children: \.children) { item in
+            item.unfurledView
+        }
+            .listStyle(SidebarListStyle())
+    }
+
+    #else
+
     public var body: some View {
         ForEach(self.manager.allItems(), id: \.id) { item in
             item.unfurledView
         }
             .environmentObject(self.manager)
     }
+
+    #endif
 }
 
 #endif

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -35,11 +35,15 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
         }
             .listStyle(SidebarListStyle())
             .toolbar {
+                #if compiler(>=5.3)
+
                 ToolbarItem(placement: .navigation) {
                     Button(action: NSApp.toggleKeyWindowSidebar) {
                         Image(systemName: "sidebar.left")
                     }
                 }
+                
+                #endif
             }
     }
 

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -30,21 +30,28 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
     #if os(macOS)
 
     public var body: some View {
-        List(self.manager.allItems(), id: \.id, children: \.children) { item in
+        let list = List(self.manager.allItems(), id: \.id, children: \.children) { item in
             item.unfurledView
         }
             .listStyle(SidebarListStyle())
-            .toolbar {
-                #if compiler(>=5.3)
 
+
+        #if compiler(>=5.3)
+
+        return list
+            .toolbar {
                 ToolbarItem(placement: .navigation) {
                     Button(action: NSApp.toggleKeyWindowSidebar) {
                         Image(systemName: "sidebar.left")
                     }
                 }
-                
-                #endif
             }
+
+        #else
+
+        return list
+
+        #endif
     }
 
     #else


### PR DESCRIPTION
### 📒 Description

Improves the UI appearance of Vexillographer on the Mac, including:

- Adds a modern toolbar, including the selected flag group title, and a sidebar toggle.
- Separates the description from the content on the Mac, and re-pads it.

### 🔍 Detailed Design

<img width="1012" alt="Screen Shot 2020-10-11 at 8 58 11 pm" src="https://user-images.githubusercontent.com/11711893/95676522-62b27180-0c0a-11eb-8151-7f8387a0c925.png">
<img width="1012" alt="Screen Shot 2020-10-11 at 9 19 10 pm" src="https://user-images.githubusercontent.com/11711893/95676523-63e39e80-0c0a-11eb-8c95-62d9983315bd.png">

### 🧯 Source Impact

What is the impact of this change on existing users? Does it deprecate or remove any existing API?

- Improved macOS appearance
- Tweaks iOS appearance

### ✅ Checklist

- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary