### PR TITLE
Improve Detail Button behaviour in iOS forms

### DIFF
--- a/Sources/Vexillographer/DetailButton.swift
+++ b/Sources/Vexillographer/DetailButton.swift
@@ -21,7 +21,6 @@ struct DetailButton: View {
 
     @State private var isDraggingInside = false
 
-
     // MARK: - View
 
 #if os(iOS)

--- a/Sources/Vexillographer/DetailButton.swift
+++ b/Sources/Vexillographer/DetailButton.swift
@@ -14,7 +14,12 @@ struct DetailButton: View {
     // MARK: - Properties
 
     let hasChanges: Bool
+
     @Binding var showDetail: Bool
+
+    @State private var size = CGSize.zero
+
+    @State private var isDraggingInside = false
 
 
     // MARK: - View
@@ -22,11 +27,36 @@ struct DetailButton: View {
 #if os(iOS)
 
     var body: some View {
-        Button (
-            action: {},
-            label: { Image(systemName: self.hasChanges ? "info.circle.fill" : "info.circle") }
-        )
-            .onTapGesture { self.showDetail.toggle() }
+        Image(systemName: self.hasChanges ? "info.circle.fill" : "info.circle")
+            .imageScale(.large)
+            .foregroundColor(.accentColor)
+            .opacity(self.isDraggingInside ? 0.3 : 1)
+            .animation(self.isDraggingInside ? .easeOut(duration: 0.15) : .easeIn(duration: 0.2), value: self.isDraggingInside)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .preference(key: SizePreferenceKey.self, value: proxy.size)
+                }
+            )
+            .onPreferenceChange(SizePreferenceKey.self) { size in
+                self.size = size
+            }
+            .gesture(selectionGesture)
+    }
+
+    private var selectionGesture: some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { data in
+                self.isDraggingInside = CGRect(origin: .zero, size: size)
+                    .insetBy(dx: -10, dy: -10)
+                    .contains(data.location)
+            }
+            .onEnded { _ in
+                if self.isDraggingInside {
+                    self.showDetail.toggle()
+                    self.isDraggingInside = false
+                }
+            }
     }
 
 #elseif os(macOS)
@@ -40,3 +70,12 @@ struct DetailButton: View {
 }
 
 #endif
+
+private struct SizePreferenceKey: PreferenceKey {
+    typealias Value = CGSize
+    static var defaultValue: Value = .zero
+
+    static func reduce(value: inout Value, nextValue: () -> Value) {
+        value = nextValue()
+    }
+}

--- a/Sources/Vexillographer/DetailButton.swift
+++ b/Sources/Vexillographer/DetailButton.swift
@@ -69,13 +69,15 @@ struct DetailButton: View {
 }
 
 private struct SizePreferenceKey: PreferenceKey {
+
     typealias Value = CGSize
+
     static var defaultValue: Value = .zero
 
     static func reduce(value: inout Value, nextValue: () -> Value) {
         value = nextValue()
     }
+
 }
 
 #endif
-

--- a/Sources/Vexillographer/DetailButton.swift
+++ b/Sources/Vexillographer/DetailButton.swift
@@ -46,7 +46,7 @@ struct DetailButton: View {
     private var selectionGesture: some Gesture {
         DragGesture(minimumDistance: 0)
             .onChanged { data in
-                self.isDraggingInside = CGRect(origin: .zero, size: size)
+                self.isDraggingInside = CGRect(origin: .zero, size: self.size)
                     .insetBy(dx: -10, dy: -10)
                     .contains(data.location)
             }

--- a/Sources/Vexillographer/DetailButton.swift
+++ b/Sources/Vexillographer/DetailButton.swift
@@ -68,8 +68,6 @@ struct DetailButton: View {
 
 }
 
-#endif
-
 private struct SizePreferenceKey: PreferenceKey {
     typealias Value = CGSize
     static var defaultValue: Value = .zero
@@ -78,3 +76,6 @@ private struct SizePreferenceKey: PreferenceKey {
         value = nextValue()
     }
 }
+
+#endif
+


### PR DESCRIPTION
### 📒 Description

Improve detail button on iOS to not *be* a button, because buttons in rows cause issues with `Form` on iOS where it thinks it's a link and forces the row to allow selection.

### 🔍 Detailed Design

This change doesn't surface any new API, but internally switches from a button to an internal view with a gesture recogniser. This gesture replicates the behaviour of `UIButton`, where the button is considered highlighted whenever the selection is within around 10 points of the view. You are required to begin within the view for the gesture to begin. Then, selection is only considered "chosen" when view is highlighted and the touch ends.

### 📓 Documentation Plan

How has the new feature been documented? Have the relevant portions of the guide been updated in addition to symbol-level documentation?

### 🗳 Test Plan

How is the new feature tested?

### 🧯 Source Impact

What is the impact of this change on existing users? Does it deprecate or remove any existing API?

- Toggle items in forms in Vexillology do not select when the user touches down on them.
- The ℹ️ button is slightly larger to match iOS styles.

### ✅ Checklist

- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary