### PR TITLE
Improve "Clear Flag" button with animation instead of removal

### DIFF
--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -85,8 +85,8 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
                     Text("Clear Flag Value in Current Source")
                 }
                     .foregroundColor(.red)
+                    .opacity(self.isCurrentSourceSet ? 1 : 0.3)
                     .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
-                    .buttonStyle(PlainButtonStyle())
                     .disabled(self.isCurrentSourceSet == false)
                     .animation(.easeInOut, value: self.isCurrentSourceSet)
             }

--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -80,15 +80,15 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
                     Spacer()
                     self.description(source: self.manager.source)
                 }
-                if self.flagValue(source: self.manager.source) != nil {
-                    HStack {
-                        Button(action: self.clearValue) {
-                            Text("Clear Flag Value in Current Source")
-                                .foregroundColor(.red)
-                        }
-                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
-                    }
+
+                Button(action: self.clearValue) {
+                    Text("Clear Flag Value in Current Source")
                 }
+                    .foregroundColor(.red)
+                    .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+                    .buttonStyle(PlainButtonStyle())
+                    .disabled(self.isCurrentSourceSet == false)
+                    .animation(.easeInOut, value: self.isCurrentSourceSet)
             }
 
             Section(header: Text("FlagPole Source Hierarchy")) {
@@ -128,6 +128,11 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
     func clearValue () {
         try? self.manager.source.setFlagValue(Optional<Value>.none, key: self.flag.flag.key)        // swiftlint:disable:this syntactic_sugar
     }
+
+    var isCurrentSourceSet: Bool {
+        self.flagValue(source: self.manager.source) != nil
+    }
+
 }
 
 #endif


### PR DESCRIPTION
### 📒 Description

Improves the Vexillographer Flag Detail screen by avoiding removing the button on selection.

### 🔍 Detailed Design

![Screen Recording 2020-10-15 at 10 23 47 pm](https://user-images.githubusercontent.com/11711893/96117650-264a8280-0f36-11eb-8001-b1a6b067ff34.gif)

### 📓 Documentation Plan

N/A

### 🗳 Test Plan

Test the button appears as above when Clear Flag is selected.

### 🧯 Source Impact

What is the impact of this change on existing users? Does it deprecate or remove any existing API?

N/A

### ✅ Checklist

- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary