### PR TITLE
Improve FlagGroupView on the Mac

### DIFF
--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -54,7 +54,11 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
 
         Form {
             Section {
-                self.flags
+                // Filter out all items that have children. They'll have navigation
+                // links that won't work on the mac flag group view.
+                ForEach(self.group.allItems().filter({ $0.hasChildren == false }), id: \.id) { item in
+                    item.unfurledView
+                }
             }
         }
             .padding([.leading, .trailing, .bottom], 30)


### PR DESCRIPTION
### 📒 Description

Improve FlagGroupView on the Mac. Currently, the flag group view displays navigation links which don't work in the detail view. This change filters them out.

### 📓 Documentation Plan

How has the new feature been documented? Have the relevant portions of the guide been updated in addition to symbol-level documentation?

N/A

### 🗳 Test Plan

How is the new feature tested?

Test descendant flag groups don't show on the Mac in the detail group when you select the parent group.

### 🧯 Source Impact

What is the impact of this change on existing users? Does it deprecate or remove any existing API?

Removes unused buttons.

### ✅ Checklist

- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary