### PR TITLE
Add Mac flag detail view with context menu

### DIFF
--- a/Sources/Vexillographer/CopyButton.swift
+++ b/Sources/Vexillographer/CopyButton.swift
@@ -5,6 +5,8 @@
 //  Created by Rod Brown on 15/11/20.
 //
 
+#if os(iOS) || os(macOS)
+
 import SwiftUI
 
 struct CopyButton: View {
@@ -28,3 +30,5 @@ struct CopyButton: View {
     }
 
 }
+
+#endif

--- a/Sources/Vexillographer/CopyButton.swift
+++ b/Sources/Vexillographer/CopyButton.swift
@@ -1,0 +1,30 @@
+//
+//  CopyButton.swift
+//  Vexil: Vexillographer
+//
+//  Created by Rod Brown on 15/11/20.
+//
+
+import SwiftUI
+
+struct CopyButton: View {
+
+    private let action: () -> Void
+
+    init(action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    var body: some View {
+        #if compiler(>=5.3.1)
+        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
+            return Button(action: self.action) {
+                Label("Copy", systemImage: "doc.on.doc")
+            }.eraseToAnyView()
+        }
+        #endif
+        return Button("Copy", action: self.action)
+            .eraseToAnyView()
+    }
+
+}

--- a/Sources/Vexillographer/FlagDetailSection.swift
+++ b/Sources/Vexillographer/FlagDetailSection.swift
@@ -22,12 +22,12 @@ struct FlagDetailSection<Header, Content>: View where Header: View, Content: Vie
 
     var body: some View {
         GroupBox(label: self.header) {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
                 self.content
             }
                 .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4))
                 .frame(maxWidth: .infinity, alignment: .leading)
-        }
+        }.padding(.bottom, 8)
     }
 
     #else

--- a/Sources/Vexillographer/FlagDetailSection.swift
+++ b/Sources/Vexillographer/FlagDetailSection.swift
@@ -1,0 +1,43 @@
+//
+//  FlagDetailSection.swift
+//  Vexil: Vexilographer
+//
+//  Created by Rod Brown on 15/11/20.
+//
+
+import SwiftUI
+
+struct FlagDetailSection<Header, Content>: View where Header: View, Content: View {
+
+    private let header: Header
+
+    private let content: Content
+
+    init(header: Header, @ViewBuilder content: () -> Content) {
+        self.header = header
+        self.content = content()
+    }
+
+    #if os(macOS)
+
+    var body: some View {
+        GroupBox(label: self.header) {
+            VStack(alignment: .leading, spacing: 12) {
+                self.content
+            }
+                .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4))
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    #else
+
+    var body: some View {
+        Section(header: self.header) {
+            self.content
+        }
+    }
+
+    #endif
+
+}

--- a/Sources/Vexillographer/FlagDetailSection.swift
+++ b/Sources/Vexillographer/FlagDetailSection.swift
@@ -5,6 +5,8 @@
 //  Created by Rod Brown on 15/11/20.
 //
 
+#if os(iOS) || os(macOS)
+
 import SwiftUI
 
 struct FlagDetailSection<Header, Content>: View where Header: View, Content: View {
@@ -41,3 +43,5 @@ struct FlagDetailSection<Header, Content>: View where Header: View, Content: Vie
     #endif
 
 }
+
+#endif

--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -5,8 +5,6 @@
 //  Created by Rob Amos on 29/6/20.
 //
 
-// swiftlint:disable multiple_closures_with_trailing_closure
-
 #if os(iOS) || os(macOS)
 
 import SwiftUI

--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -39,6 +39,15 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
             .navigationBarTitle(Text(self.flag.info.name), displayMode: .inline)
     }
 
+    #elseif os(macOS)
+
+    var body: some View {
+        ScrollView {
+            self.content
+        }
+        .frame(minWidth: 300)
+    }
+
     #else
 
     var body: some View {
@@ -50,30 +59,22 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
 
     var content: some View {
         Form {
-            Section(header: Text("Flag Details")) {
-                HStack {
-                    Text("Key").font(.headline)
-                    Spacer()
-                    Text(self.flag.info.key)
-                }
+            FlagDetailSection(header: Text("Flag Details")) {
+                self.flagKeyView
                     .contextMenu {
-                        Button(action: { self.flag.info.key.copyToPasteboard() }) {
-                            Text("Copy key to clipboard")
-                        }
+                        CopyButton(action: self.flag.info.key.copyToPasteboard)
                     }
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Description").font(.headline)
+                VStack(alignment: .leading) {
+                    Text("Description:").font(.headline)
                     Text(self.flag.info.description)
                 }
-                    .contextMenu {
-                        Button(action: { self.flag.info.description.copyToPasteboard() }) {
-                            Text("Copy description to clipboard")
-                        }
-                    }
+                .contextMenu {
+                    CopyButton(action: self.flag.info.description.copyToPasteboard)
+                }
             }
 
-            Section(header: Text("Current Source")) {
+            FlagDetailSection(header: Text("Current Source")) {
                 HStack {
                     Text(self.manager.source.name)
                         .font(.headline)
@@ -84,14 +85,14 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
                 Button(action: self.clearValue) {
                     Text("Clear Flag Value in Current Source")
                 }
-                    .foregroundColor(.red)
-                    .opacity(self.isCurrentSourceSet ? 1 : 0.3)
-                    .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
-                    .disabled(self.isCurrentSourceSet == false)
-                    .animation(.easeInOut, value: self.isCurrentSourceSet)
+                .foregroundColor(.red)
+                .opacity(self.isCurrentSourceSet ? 1 : 0.3)
+                .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+                .disabled(self.isCurrentSourceSet == false)
+                .animation(.easeInOut, value: self.isCurrentSourceSet)
             }
 
-            Section(header: Text("FlagPole Source Hierarchy")) {
+            FlagDetailSection(header: Text("FlagPole Source Hierarchy")) {
                 ForEach(self.manager.flagPole._sources, id: \.name) { source in
                     HStack {
                         if (source as AnyObject) === (self.manager.source as AnyObject) {
@@ -131,6 +132,25 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
 
     var isCurrentSourceSet: Bool {
         self.flagValue(source: self.manager.source) != nil
+    }
+
+    private var flagKeyView: some View {
+        #if os(macOS)
+
+        return VStack(alignment: .leading) {
+            Text("Key").font(.headline)
+            Text(self.flag.info.key)
+        }
+
+        #else
+
+        return HStack {
+            Text("Key").font(.headline)
+            Spacer()
+            Text(self.flag.info.key)
+        }
+
+        #endif
     }
 
 }

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -85,15 +85,7 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
             Text(self.group.info.description)
         }
             .contextMenu {
-                Button(action: self.group.info.description.copyToPasteboard) { () -> AnyView in
-                    #if compiler(>=5.3.1)
-                    if #available(iOS 14, watchOS 7, tvOS 14, *) {
-                        return Label("Copy", systemImage: "doc.on.doc").eraseToAnyView()
-                    }
-                    #endif
-
-                    return Text("Copy").eraseToAnyView()
-                }
+                CopyButton(action: self.group.info.description.copyToPasteboard)
             }
     }
 

--- a/Sources/Vexillographer/FlagView.swift
+++ b/Sources/Vexillographer/FlagView.swift
@@ -34,6 +34,9 @@ struct UnfurledFlagView<Value, RootGroup>: View where Value: FlagValue, RootGrou
 
     var body: some View {
         self.content
+            .contextMenu {
+                Button("Show Details") { self.showDetail = true }
+            }
             .sheet (
                 isPresented: self.$showDetail,
                 content: {
@@ -78,9 +81,14 @@ struct UnfurledFlagView<Value, RootGroup>: View where Value: FlagValue, RootGrou
     #elseif os(macOS)
 
     var detailView: some View {
-        NavigationView {
+        VStack {
             FlagDetailView(flag: self.flag, manager: self.manager)
+            HStack {
+                Spacer()
+                self.detailDoneButton
+            }
         }
+        .padding()
     }
 
     #endif

--- a/Sources/Vexillographer/FlagView.swift
+++ b/Sources/Vexillographer/FlagView.swift
@@ -94,10 +94,9 @@ struct UnfurledFlagView<Value, RootGroup>: View where Value: FlagValue, RootGrou
     #endif
 
     var detailDoneButton: some View {
-        Button (
-            action: { self.showDetail = false },
-            label: { Text("Close").font(.headline) }
-        )
+        Button("Close") {
+            self.showDetail = false
+        }
     }
 
 }

--- a/Sources/Vexillographer/Utilities/AnyView.swift
+++ b/Sources/Vexillographer/Utilities/AnyView.swift
@@ -5,6 +5,8 @@
 //  Created by Rob Amos on 29/6/20.
 //
 
+#if os(iOS) || os(macOS)
+
 import SwiftUI
 
 extension View {
@@ -12,3 +14,5 @@ extension View {
         return AnyView(self)
     }
 }
+
+#endif

--- a/Sources/Vexillographer/Utilities/AnyView.swift
+++ b/Sources/Vexillographer/Utilities/AnyView.swift
@@ -5,8 +5,6 @@
 //  Created by Rob Amos on 29/6/20.
 //
 
-#if os(iOS) || os(macOS)
-
 import SwiftUI
 
 extension View {
@@ -14,5 +12,3 @@ extension View {
         return AnyView(self)
     }
 }
-
-#endif


### PR DESCRIPTION
### 📒 Description

- Adds flag detail view with a context menu on the Mac
- Adds flag detail context menu option on iOS

### 🔍 Detailed Design

- Redesigns the appearance to remove NavigationView on the Mac as it doesn't present correctly.
- Refactors sections to use group boxes on the Mac
- Refactors copy buttons to a separate place to show an icon when used as a context menu on iOS 14 and later.

### 📓 Documentation Plan

N/A

### 🗳 Test Plan

Test right clicking on flag editor for each flag shows a "Show Detail" context menu.

### 🧯 Source Impact

N/A

### ✅ Checklist

- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary