### PR TITLE
Fixed issue on iOS where FlagGroup's displayed as sections were being nested inside SwiftUI Section views, causing rendering issues

### DIFF
--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -35,9 +35,7 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
         Form {
             self.description
                 .padding([.top, .bottom], 4)
-            Section(header: Text("Flags")) {
-                self.flags
-            }
+            self.flags
         }
             .navigationBarTitle(Text(self.group.info.name), displayMode: .inline)
     }


### PR DESCRIPTION
### 📒 Description

Using a `FlagGroup.Display` value of `.section` could lead to rendering issues when it was nested inside another FlagGroup.

eg.

```
FlagGroup(display: .navigation)
└── FlagGroup(display: .section)
```

Would cause the section `FlagGroup` to be rendered in nested SwiftUI [Section](https://developer.apple.com/documentation/swiftui/section) views, leading to rendering issues.

### 🗳 Test Plan

Tested in the simulator.

### ✅ Checklist

- ~I've added at least one test that validates that my change is working, if appropriate~
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- ~I've updated the documentation if necessary~