### PR TITLE
Updated the matrix of supported Xcode / OS versions to include the November releases

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -13,11 +13,35 @@ on:
       - '**/*.swift'
     
 jobs:
+  test-ios-xcode-12_3:
+    name: iOS Tests - Xcode 12.3 (beta)
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
+
   test-ios-xcode-12_2:
     name: iOS Tests - Xcode 12.2
     runs-on: macOS-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
+
+  test-ios-xcode-12_1:
+    name: iOS Tests - Xcode 12.1.1
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.1.1.app/Contents/Developer
 
     steps:
       - name: Checkout

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -14,6 +14,86 @@ on:
     
 jobs:
 
+  # Swift 5.3.1
+
+  test-5_3_1-amazon-linux:
+    name: Linux Tests - Swift 5.3.1 - Amazon Linux 2
+    runs-on: ubuntu-latest
+
+    container:
+      image: swift:5.3.1-amazonlinux2
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Build and Test
+        run: swift test --enable-test-discovery
+
+  test-5_3_1-bionic:
+    name: Linux Tests - Swift 5.3.1 - Ubuntu 18.04
+    runs-on: ubuntu-latest
+
+    container:
+      image: swift:5.3.1-bionic
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Build and Test
+        run: swift test --enable-test-discovery
+
+  test-5_3_1-centos7:
+    name: Linux Tests - Swift 5.3.1 - CentOS 7
+    runs-on: ubuntu-latest
+
+    container:
+      image: swift:5.3.1-centos7
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Build and Test
+        run: swift test --enable-test-discovery
+
+  test-5_3_1-centos8:
+    name: Linux Tests - Swift 5.3.1 - CentOS 8
+    runs-on: ubuntu-latest
+
+    container:
+      image: swift:5.3.1-centos8
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Build and Test
+        run: swift test --enable-test-discovery
+
+  test-5_3_1-focal:
+    name: Linux Tests - Swift 5.3.1 - Ubuntu 20.04
+    runs-on: ubuntu-latest
+
+    container:
+      image: swift:5.3.1-focal
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Build and Test
+        run: swift test --enable-test-discovery
+
+  test-5_3_1-xenial:
+    name: Linux Tests - Swift 5.3.1 - Ubuntu 16.04
+    runs-on: ubuntu-latest
+
+    container:
+      image: swift:5.3.1-xenial
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Build and Test
+        run: swift test --enable-test-discovery
+
   # Swift 5.3
 
   test-5_3-amazon-linux:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -13,11 +13,35 @@ on:
       - '**/*.swift'
     
 jobs:
+  test-macos-xcode-12_3:
+    name: macOS Tests - Xcode 12.3 (beta)
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift test
+
   test-macos-xcode-12_2:
     name: macOS Tests - Xcode 12.2
     runs-on: macOS-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift test
+
+  test-macos-xcode-12_1:
+    name: macOS Tests - Xcode 12.1.1
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.1.1.app/Contents/Developer
 
     steps:
       - name: Checkout
@@ -40,6 +64,42 @@ jobs:
   test-macos-xcode-11:
     name: macOS Tests - Xcode 11
     runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift test
+
+  test-macos-11-xcode-12_3:
+    name: macOS 11 Tests - Xcode 12.3 (beta)
+    runs-on: macos-11.0
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift test
+
+  test-macos-11-xcode-12_2:
+    name: macOS 11 Tests - Xcode 12.2
+    runs-on: macos-11.0
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift test
+
+  test-macos-11-xcode-11:
+    name: macOS Tests - Xcode 11
+    runs-on: macos-11.0
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
 

--- a/.github/workflows/tvos-tests.yml
+++ b/.github/workflows/tvos-tests.yml
@@ -13,11 +13,35 @@ on:
       - '**/*.swift'
     
 jobs:
+  test-tvos-xcode-12_3:
+    name: tvOS Tests - Xcode 12.3 (beta)
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=tvOS Simulator,name=Apple TV 4K"
+
   test-tvos-xcode-12_2:
     name: tvOS Tests - Xcode 12.2
     runs-on: macOS-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=tvOS Simulator,name=Apple TV 4K"
+
+  test-tvos-xcode-12_1:
+    name: tvOS Tests - Xcode 12.1.1
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.1.1.app/Contents/Developer
 
     steps:
       - name: Checkout

--- a/.github/workflows/watchos-tests.yml
+++ b/.github/workflows/watchos-tests.yml
@@ -13,11 +13,35 @@ on:
       - '**/*.swift'
     
 jobs:
+  build-watchos-xcode-12_3:
+    name: watchOS Build - Xcode 12.3 (beta)
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift package generate-xcodeproj && xcrun xcodebuild build -scheme "Vexil-Package" -destination "generic/platform=watchos"
+
   build-watchos-xcode-12_2:
     name: watchOS Build - Xcode 12.2
     runs-on: macOS-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: swift package generate-xcodeproj && xcrun xcodebuild build -scheme "Vexil-Package" -destination "generic/platform=watchos"
+
+  build-watchos-xcode-12_1:
+    name: watchOS Build - Xcode 12.1.1
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.1.1.app/Contents/Developer
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### 📒 Description

Adds support for:

#### iOS 

| Host OS | Xcode Version | Target OS(s) |
|---------|-------|------|
| Catalina | 12.3 (beta) | iOS 14.3 (beta) |
| Catalina | 12.1.1 | iOS 14.2 |

#### macOS

| Host OS | Xcode Version | Target OS(s) |
|---------|-------|------|
| Catalina | 12.3 (beta) | macOS 11.1 |
| Catalina | 12.1.1 | macOS 10.15 |
| Big Sur | 12.3 (beta) | macOS 11.1 |
| Big Sur | 12.2 | macOS 11.0 |
| Big Sur | 11.7 | macOS 10.15 |

#### tvOS
 
| Host OS | Xcode Version | Target OS(s) |
|---------|-------|------|
| Catalina | 12.3 (beta) | tvOS 14.3 (beta) |
| Catalina | 12.1.1 | tvOS 14.2 |

#### watchOS

| Host OS | Xcode Version | Target OS(s) |
|---------|-------|------|
| Catalina | 12.3 (beta) | watchOS 7.2 (beta) |
| Catalina | 12.1.1 | watchOS 7.1 |




