### PR TITLE
Improve section-styled FlagGroup display

### DIFF
--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -44,24 +44,26 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
     #elseif os(macOS) && compiler(>=5.3.1)
 
     var body: some View {
-        VStack(alignment: .leading) {
-            self.description
-                .padding(.bottom, 8)
-            Divider()
-        }
+        ScrollView {
+            VStack(alignment: .leading) {
+                self.description
+                    .padding(.bottom, 8)
+                Divider()
+            }
             .padding()
 
-        Form {
-            Section {
-                // Filter out all links. They won't work on the mac flag group view.
-                ForEach(self.group.allItems().filter({ $0.isLink == false }), id: \.id) { item in
-                    item.unfurledView
+            Form {
+                Section {
+                    // Filter out all links. They won't work on the mac flag group view.
+                    ForEach(self.group.allItems().filter({ $0.isLink == false }), id: \.id) { item in
+                        item.unfurledView
+                    }
                 }
             }
-        }
             .padding([.leading, .trailing, .bottom], 30)
             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
-            .navigationTitle(self.group.info.name)
+        }
+        .navigationTitle(self.group.info.name)
     }
 
     #else

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -50,7 +50,7 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
                     .padding(.bottom, 8)
                 Divider()
             }
-            .padding()
+                .padding()
 
             Form {
                 Section {
@@ -60,10 +60,10 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
                     }
                 }
             }
-            .padding([.leading, .trailing, .bottom], 30)
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
+                .padding([.leading, .trailing, .bottom], 30)
+                .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
         }
-        .navigationTitle(self.group.info.name)
+            .navigationTitle(self.group.info.name)
     }
 
     #else

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -33,11 +33,12 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
 
     var body: some View {
         Form {
-            self.description
+            Section {
+                self.description
+            }
                 .padding([.top, .bottom], 4)
             self.flags
         }
-            .navigationBarTitle(Text(self.group.info.name), displayMode: .inline)
     }
 
     #elseif os(macOS) && compiler(>=5.3.1)
@@ -52,9 +53,8 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
 
         Form {
             Section {
-                // Filter out all items that have children. They'll have navigation
-                // links that won't work on the mac flag group view.
-                ForEach(self.group.allItems().filter({ $0.hasChildren == false }), id: \.id) { item in
+                // Filter out all links. They won't work on the mac flag group view.
+                ForEach(self.group.allItems().filter({ $0.isLink == false }), id: \.id) { item in
                     item.unfurledView
                 }
             }

--- a/Sources/Vexillographer/FlagSectionView.swift
+++ b/Sources/Vexillographer/FlagSectionView.swift
@@ -29,32 +29,42 @@ struct UnfurledFlagSectionView<Group, Root>: View where Group: FlagContainer, Ro
 
     // MARK: - View Body
 
-    #if os(iOS)
+    #if os(macOS)
 
     var body: some View {
-        self.content
-            .navigationBarTitle(Text(self.group.info.name), displayMode: .inline)
+        GroupBox(
+            label: Text(self.group.info.name),
+            content: {
+                VStack(alignment: .leading) {
+                    Text(self.group.info.description)
+                    Divider()
+                    self.content
+                }.padding(4)
+            }
+        )
+        .padding([.top, .bottom])
     }
 
     #else
 
     var body: some View {
-        self.content
-    }
-
-    #endif
-
-    var content: some View {
         Section (
             header: Text(self.group.info.name),
             footer: Text(self.group.info.description),
             content: {
-                ForEach(self.group.allItems(), id: \.id) { item in
-                    item.unfurledView
-                }
+                self.content
             }
         )
     }
+
+    #endif
+
+    private var content: some View {
+        ForEach(self.group.allItems(), id: \.id) { item in
+            item.unfurledView
+        }
+    }
+
 }
 
 #endif

--- a/Sources/Vexillographer/Unfurling/UnfurledFlag.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlag.swift
@@ -35,10 +35,13 @@ struct UnfurledFlag<Value, RootGroup>: UnfurledFlagItem, Identifiable where Valu
             || self is OptionalStringEditableFlag
     }
 
-    var children: [UnfurledFlagItem]? {
+    var childLinks: [UnfurledFlagItem]? {
         return nil
     }
 
+    var isLink: Bool {
+        return false
+    }
 
     // MARK: - Initialisation
 

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
@@ -81,7 +81,7 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
             .navigationBarTitle(Text(self.info.name), displayMode: .inline)
             .eraseToAnyView()
 
-        #else
+        #elseif compiler(>=5.3.1)
 
         destination = destination
             .navigationTitle(self.info.name)

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
@@ -31,8 +31,12 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
             .isEmpty == false
     }
 
-    var children: [UnfurledFlagItem]? {
-        let children = self.allItems().filter { $0.hasChildren == true }
+    var isLink: Bool {
+        return self.group.display == .navigation
+    }
+
+    var childLinks: [UnfurledFlagItem]? {
+        let children = self.allItems().filter { $0.hasChildren == true && $0.isLink }
         return children.isEmpty == false ? children : nil
     }
 
@@ -60,19 +64,39 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
     var unfurledView: AnyView {
         switch self.group.display {
         case .navigation:
-            return NavigationLink(destination: UnfurledFlagGroupView(group: self, manager: self.manager)) {
-                HStack {
-                    Text(self.info.name)
-                        .font(.headline)
-                }
-            }
-                .eraseToAnyView()
+            return self.unfurledNavigationLink
 
         case .section:
             return UnfurledFlagSectionView(group: self, manager: self.manager)
                 .eraseToAnyView()
         }
     }
+
+    private var unfurledNavigationLink: AnyView {
+        var destination = UnfurledFlagGroupView(group: self, manager: self.manager).eraseToAnyView()
+
+        #if os(iOS)
+
+        destination = destination
+            .navigationBarTitle(Text(self.info.name), displayMode: .inline)
+            .eraseToAnyView()
+
+        #else
+
+        destination = destination
+            .navigationTitle(self.info.name)
+            .eraseToAnyView()
+
+        #endif
+
+        return NavigationLink(destination: destination) {
+            HStack {
+                Text(self.info.name)
+                    .font(.headline)
+            }
+        }.eraseToAnyView()
+    }
+
 }
 
 #endif

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
@@ -16,9 +16,10 @@ protocol UnfurledFlagItem {
     var id: UUID { get }
     var info: UnfurledFlagInfo { get }
     var hasChildren: Bool { get }
-    var children: [UnfurledFlagItem]? { get }
+    var childLinks: [UnfurledFlagItem]? { get }
     var unfurledView: AnyView { get }
     var isEditable: Bool { get }
+    var isLink: Bool { get }
 }
 
 #endif

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -30,7 +30,7 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
     #if os(macOS) && compiler(>=5.3.1)
 
     public var body: some View {
-        List(self.manager.allItems(), id: \.id, children: \.children) { item in
+        List(self.manager.allItems(), id: \.id, children: \.childLinks) { item in
             item.unfurledView
         }
             .listStyle(SidebarListStyle())


### PR DESCRIPTION
<!--
    Thanks for contributing to Vexil!

    Before you submit your request, please replace each paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### 📒 Description

Improves display of `FlagGroup`s where they use `section` display style.
- On Mac, uses group boxes and extracts them from the sidebar. Sidebars should be limited to links only.
- On iOS, uses inline sections and corrects cases where the description was morphed with the first flag section.

### 🔍 Detailed Design

This required changing some of the API of `UnfurledFlagItem` to better reflect what `children` is required to fetch for the navigation link system - child links. Declaring whether the item is itself a link, and what links the item contains, means we can limit the sidebar to child items which represent navigation links, and allow `section` types to be hosted in their parent `FlagGroupView` on the Mac. On iOS, these show as similarly grouped sections in their parent groups, and links show inline on the `FlagGroupView` rather than in the sidebar.

Currently this doesn't work for top level flags, but it should be relatively easy to now filter out any elements that aren't links on the sidebar. We can then create a single link to start the sidebar list for that top level group. This can follow in a later PR.

### 📓 Documentation Plan

N/A

### 🗳 Test Plan

How is the new feature tested?

Test in iOS simulator and on the Mac

### 🧯 Source Impact

No external source impact. Internal API has changed somewhat around unfurling behaviours.

### ✅ Checklist

- ~I've added at least one test that validates that my change is working, if appropriate~
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- ~I've updated the documentation if necessary~