### PR TITLE
Added support for lossless decoding

### DIFF
--- a/Sources/Vexil/Value.swift
+++ b/Sources/Vexil/Value.swift
@@ -80,8 +80,14 @@ extension Bool: FlagValue {
     public typealias BoxedValueType = Bool
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .bool(let value) = boxedFlagValue else { return nil }
-        self = value
+        switch boxedFlagValue {
+        case let .bool(value):          self = value
+        case let .integer(value):       self = value != 0
+        case let .float(value):         self = value != 0.0
+        case let .double(value):        self = value != 0.0
+        case let .string(value):        self = (value as NSString).boolValue
+        default:                        return nil
+        }
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -150,8 +156,13 @@ extension Double: FlagValue {
     public typealias BoxedValueType = Double
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .double(let value) = boxedFlagValue else { return nil }
-        self = value
+        switch boxedFlagValue {
+        case let .double(value):            self = value
+        case let .float(value):             self = Double(value)
+        case let .integer(value):           self = Double(value)
+        case let .string(value):            self = (value as NSString).doubleValue
+        default:                            return nil
+        }
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -164,9 +175,11 @@ extension Float: FlagValue {
 
     public init? (boxedFlagValue: BoxedFlagValue) {
         switch boxedFlagValue {
-        case let .float(value):         self = value
-        case let .double(value):        self = Float(value)
-        default:                        return nil
+        case let .float(value):             self = value
+        case let .double(value):            self = Float(value)
+        case let .integer(value):           self = Float(value)
+        case let .string(value):            self = (value as NSString).floatValue
+        default:                            return nil
         }
     }
 
@@ -179,8 +192,11 @@ extension Int: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
-        self = value
+        switch boxedFlagValue {
+        case let .integer(value):           self = value
+        case let .string(value):            self = (value as NSString).integerValue
+        default:                            return nil
+        }
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -192,7 +208,7 @@ extension Int8: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
+        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
         self = Int8(value)
     }
 
@@ -205,7 +221,7 @@ extension Int16: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
+        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
         self = Int16(value)
     }
 
@@ -218,7 +234,7 @@ extension Int32: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
+        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
         self = Int32(value)
     }
 
@@ -231,7 +247,7 @@ extension Int64: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
+        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
         self = Int64(value)
     }
 
@@ -244,7 +260,7 @@ extension UInt: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
+        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
         self = UInt(value)
     }
 
@@ -257,7 +273,7 @@ extension UInt8: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
+        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
         self = UInt8(value)
     }
 
@@ -270,7 +286,7 @@ extension UInt16: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
+        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
         self = UInt16(value)
     }
 
@@ -283,7 +299,7 @@ extension UInt32: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
+        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
         self = UInt32(value)
     }
 
@@ -296,7 +312,7 @@ extension UInt64: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard case .integer(let value) = boxedFlagValue else { return nil }
+        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
         self = UInt64(value)
     }
 

--- a/Tests/VexilTests/UserDefaultsDecodingTests.swift
+++ b/Tests/VexilTests/UserDefaultsDecodingTests.swift
@@ -57,6 +57,27 @@ final class UserDefaultsDecodingTests: XCTestCase {
         XCTAssertEqual(self.defaults.flagValue(key: #function), value)
     }
 
+    func testDecodeBooleanInt () {
+        let value = 1
+
+        self.defaults.set(value, forKey: #function)
+        XCTAssertEqual(self.defaults.flagValue(key: #function), true)
+    }
+
+    func testDecodeBooleanDouble () {
+        let value = 1.0
+
+        self.defaults.set(value, forKey: #function)
+        XCTAssertEqual(self.defaults.flagValue(key: #function), true)
+    }
+
+    func testDecodeBooleanString () {
+        let value = "t"
+
+        self.defaults.set(value, forKey: #function)
+        XCTAssertEqual(self.defaults.flagValue(key: #function), true)
+    }
+
 
     // MARK: - Decoding String Types
 
@@ -96,6 +117,28 @@ final class UserDefaultsDecodingTests: XCTestCase {
         XCTAssertNotNil(result)
         if let result = result {
             XCTAssertEqual(result, value, accuracy: 0.000001)
+        }
+    }
+
+    func testDecodeDoubleInt () {
+        let value = 1
+
+        self.defaults.set(value, forKey: #function)
+        let result: Double? = self.defaults.flagValue(key: #function)
+        XCTAssertNotNil(result)
+        if let result = result {
+            XCTAssertEqual(result, 1.0, accuracy: 0.000001)
+        }
+    }
+
+    func testDecodeDoubleString () {
+        let value = "1.23456789"
+
+        self.defaults.set(value, forKey: #function)
+        let result: Double? = self.defaults.flagValue(key: #function)
+        XCTAssertNotNil(result)
+        if let result = result {
+            XCTAssertEqual(result, 1.23456789, accuracy: 0.000001)
         }
     }
 
@@ -172,6 +215,20 @@ final class UserDefaultsDecodingTests: XCTestCase {
         XCTAssertEqual(self.defaults.flagValue(key: #function), value)
     }
 
+    func testDecodeIntString () {
+        let value = "1234"
+
+        self.defaults.set(value, forKey: #function)
+        XCTAssertEqual(self.defaults.flagValue(key: #function), 1234)
+    }
+
+    func testDecodeUIntString () {
+        let value = "1234"
+
+        self.defaults.set(value, forKey: #function)
+        XCTAssertEqual(self.defaults.flagValue(key: #function), UInt(1234))
+    }
+
 
     // MARK: - Wrapping Types
 
@@ -220,6 +277,13 @@ final class UserDefaultsDecodingTests: XCTestCase {
         XCTAssertEqual(self.defaults.flagValue(key: #function), value)
     }
 
+    func testOptionalBoolString () {
+        let value = "t"
+        let expected: Bool?? = true
+
+        self.defaults.set(value, forKey: #function)
+        XCTAssertEqual(self.defaults.flagValue(key: #function), expected)
+    }
 
     // MARK: - Array Tests
 

--- a/Tests/VexilTests/UserDefaultsDecodingTests.swift
+++ b/Tests/VexilTests/UserDefaultsDecodingTests.swift
@@ -61,21 +61,21 @@ final class UserDefaultsDecodingTests: XCTestCase {
         let value = 1
 
         self.defaults.set(value, forKey: #function)
-        XCTAssertEqual(self.defaults.flagValue(key: #function), true)
+        XCTAssertEqual(self.defaults.flagValue(key: #function), true)       // swiftlint:disable:this xct_specific_matcher
     }
 
     func testDecodeBooleanDouble () {
         let value = 1.0
 
         self.defaults.set(value, forKey: #function)
-        XCTAssertEqual(self.defaults.flagValue(key: #function), true)
+        XCTAssertEqual(self.defaults.flagValue(key: #function), true)       // swiftlint:disable:this xct_specific_matcher
     }
 
     func testDecodeBooleanString () {
         let value = "t"
 
         self.defaults.set(value, forKey: #function)
-        XCTAssertEqual(self.defaults.flagValue(key: #function), true)
+        XCTAssertEqual(self.defaults.flagValue(key: #function), true)       // swiftlint:disable:this xct_specific_matcher
     }
 
 


### PR DESCRIPTION
### 📒 Description

Vexil was originally designed with the intent of working with multiple flag providers / sources, but was strict on type conversion.

This means we were not flexible with supporting providers that could be updated by third parties. eg if a provider only supports floats there was no conversion to doubles.

This PR adds support for lossless conversion (eg from `Float` or `String` to `Double`) and for non-zero values to be treated as `true`. The conversion rules we've used are the same as implemented in [UserDefaults](https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/UserDefaults.swift) from [swift-corelibs-foundation](https://github.com/apple/swift-corelibs-foundation/).

### 🧯 Source Impact

This change is backwards compatible.

### ✅ Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary