### PR TITLE
Filter `UserDefaults` so only the subscribed instance emits

### DIFF
--- a/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
@@ -47,6 +47,7 @@ extension UserDefaults: FlagValueSource {
     /// A Publisher that emits events when the flag values it manages changes
     public var valuesDidChange: AnyPublisher<Void, Never>? {
         return NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+            .filter { ($0.object as AnyObject) === self }
             .map { _ in () }
             .eraseToAnyPublisher()
     }
@@ -55,7 +56,9 @@ extension UserDefaults: FlagValueSource {
 
     public var valuesDidChange: AnyPublisher<Void, Never>? {
         return Publishers.Merge (
-            NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification).map { _ in () },
+            NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+                .filter { ($0.object as AnyObject) === self }
+                .map { _ in () },
             NotificationCenter.default.publisher(for: ApplicationDidBecomeActive).map { _ in () }
         )
             .eraseToAnyPublisher()

--- a/Tests/VexilTests/UserDefaultPublisherTests.swift
+++ b/Tests/VexilTests/UserDefaultPublisherTests.swift
@@ -39,6 +39,33 @@ final class UserDefaultPublisherTests: XCTestCase {
         XCTAssertEqual(snapshots.count, 2)
     }
 
+    func testDoesNotPublishWhenDifferentUserDefaultsChange () {
+        let expectation = self.expectation(description: "published")
+
+        let defaults1 = UserDefaults(suiteName: "Test Suite")!
+        let defaults2 = UserDefaults(suiteName: "Separate Test Suite")!
+        let pole = FlagPole(hoist: TestFlags.self, sources: [ defaults1 ])
+
+        var snapshots = [Snapshot<TestFlags>]()
+
+        let cancellable = pole.publisher
+            .dropFirst()                        // drop the immediate publish upon subscribing
+            .sink { snapshot in
+                snapshots.append(snapshot)
+                if snapshots.count == 1 {
+                    expectation.fulfill()
+                }
+            }
+
+        defaults2.set("Test Value", forKey: "test-key")
+        defaults1.set(123, forKey: "second-test-key")
+
+        self.wait(for: [ expectation ], timeout: 1)
+
+        XCTAssertNotNil(cancellable)
+        XCTAssertEqual(snapshots.count, 1)
+    }
+
 }
 
 


### PR DESCRIPTION
### 📒 Description

We now filter the publisher of `UserDefaults.didChangeNotification` to ensure that only the instance of `UserDefaults` you are subscribed to will trigger changes to your flags. So if you're using an app group instance of `UserDefaults` you will no longer see triggers when UIKit or other frameworks update `UserDefaults.standard`.

This would also cause flag values to flop as different instance of `UserDefaults` would have different flag values set.