### PR TITLE
Added additional publishing-based `Equatable` tests

### DIFF
--- a/Tests/VexilTests/EquatableTests.swift
+++ b/Tests/VexilTests/EquatableTests.swift
@@ -7,8 +7,12 @@
 
 // swiftlint:disable let_var_whitespace
 
-import Vexil
+@testable import Vexil
 import XCTest
+
+#if !os(Linux)
+import Combine
+#endif
 
 final class EquatableTests: XCTestCase {
 
@@ -57,6 +61,84 @@ final class EquatableTests: XCTestCase {
         XCTAssertEqual(first.subgroup, second.subgroup)
     }
 
+    // MARK: - Publisher-based Tests
+
+    #if !os(Linux)
+
+    func testPublisherEmitsEquatableElements() throws {
+
+        // GIVEN an empty dictionary and flag pole
+        let dictionary = FlagValueDictionary()
+        let pole = FlagPole(hoist: TestFlags.self, sources: [ dictionary ])
+
+        var allSnapshots: [Snapshot<TestFlags>] = []
+        var firstFilter: [Snapshot<TestFlags>] = []
+        var secondFilter: [Snapshot<TestFlags>] = []
+        var thirdFilter: [Snapshot<TestFlags>] = []
+        let expectation = self.expectation(description: "snapshot")
+
+        let cancellable = pole.publisher
+            .handleEvents (receiveOutput: { allSnapshots.append($0) })
+            .removeDuplicates()
+            .handleEvents (receiveOutput: { firstFilter.append($0) })
+            .removeDuplicates(by: { $0.subgroup == $1.subgroup })
+            .handleEvents (receiveOutput: { secondFilter.append($0) })
+            .removeDuplicates(by: { $0.subgroup.doubleSubgroup == $1.subgroup.doubleSubgroup })
+            .handleEvents (receiveOutput: { thirdFilter.append($0) })
+            .sink { snapshot in
+                if allSnapshots.count == 6 {
+                    expectation.fulfill()
+                }
+            }
+
+        // WHEN we emit, then change some values and emit more
+        dictionary["untracked-key"] = true                              // 1
+        dictionary["top-level-flag"] = true                             // 2
+        dictionary["second-test-flag"] = true                           // 3
+        dictionary["subgroup.second-level-flag"] = true                 // 4
+        dictionary["subgroup.double-subgroup.third-level-flag"] = true  // 5
+
+        // THEN we should have 6 snapshots of varying equatability
+        wait(for: [ expectation ], timeout: 0.1)
+
+        XCTAssertNotNil(cancellable)
+
+        // 1. Two shapshots should be fully Equatable if we change an untracked key
+        XCTAssertEqual(allSnapshots[safe: 0], allSnapshots[safe: 1])
+
+        // 2. Two snapshots are not Equatable, but their subgroup is when we change a top-level flag
+        XCTAssertNotNil(allSnapshots[safe: 2])
+        XCTAssertNotEqual(allSnapshots[safe: 0], allSnapshots[safe: 2])
+        XCTAssertEqual(allSnapshots[safe: 0]?.subgroup, allSnapshots[safe: 2]?.subgroup)
+
+        // 3. Two snapshots are not Equatable but their subgroup still is when we change a different top-level flag
+        //    It should also not be equal to the snapshot from test #2
+        XCTAssertNotNil(allSnapshots[safe: 3])
+        XCTAssertNotEqual(allSnapshots[safe: 0], allSnapshots[safe: 3])
+        XCTAssertNotEqual(allSnapshots[safe: 2], allSnapshots[safe: 3])
+        XCTAssertEqual(allSnapshots[safe: 0]?.subgroup, allSnapshots[safe: 3]?.subgroup)
+
+        // 4. Two snapshots should not be equal, and neither should their subgroups, when we change a flag in the subgroup
+        XCTAssertNotNil(allSnapshots[safe: 4])
+        XCTAssertNotEqual(allSnapshots[safe: 0], allSnapshots[safe: 4])
+        XCTAssertNotEqual(allSnapshots[safe: 0]?.subgroup, allSnapshots[safe: 4]?.subgroup)
+        XCTAssertEqual(allSnapshots[safe: 0]?.subgroup.doubleSubgroup, allSnapshots[safe: 4]?.subgroup.doubleSubgroup)
+
+        // 5. Two snapshots are never equal when we change a flag so that all parts of the tree are mutated
+        XCTAssertNotNil(allSnapshots[safe: 5])
+        XCTAssertNotEqual(allSnapshots[safe: 0], allSnapshots[safe: 5])
+        XCTAssertNotEqual(allSnapshots[safe: 0]?.subgroup, allSnapshots[safe: 5]?.subgroup)
+        XCTAssertNotEqual(allSnapshots[safe: 0]?.subgroup.doubleSubgroup, allSnapshots[safe: 5]?.subgroup.doubleSubgroup)
+
+        // AND we expect those to have been filtered appropriately
+        XCTAssertEqual(allSnapshots.count, 6)
+        XCTAssertEqual(firstFilter.count, 5)            // dropped the first change
+        XCTAssertEqual(secondFilter.count, 3)           // dropped 1, 2 and 3
+        XCTAssertEqual(thirdFilter.count, 2)            // dropped everything except 5
+
+    }
+
+    #endif
 }
 
 

--- a/Tests/VexilTests/EquatableTests.swift
+++ b/Tests/VexilTests/EquatableTests.swift
@@ -65,6 +65,7 @@ final class EquatableTests: XCTestCase {
 
     #if !os(Linux)
 
+    // swiftlint:disable:next function_body_length
     func testPublisherEmitsEquatableElements() throws {
 
         // GIVEN an empty dictionary and flag pole
@@ -85,7 +86,7 @@ final class EquatableTests: XCTestCase {
             .handleEvents (receiveOutput: { secondFilter.append($0) })
             .removeDuplicates(by: { $0.subgroup.doubleSubgroup == $1.subgroup.doubleSubgroup })
             .handleEvents (receiveOutput: { thirdFilter.append($0) })
-            .sink { snapshot in
+            .sink { _ in
                 if allSnapshots.count == 6 {
                     expectation.fulfill()
                 }


### PR DESCRIPTION
### 📒 Description

Added an additional test of our `Equatable` support that uses snapshots emitted by our `Publisher`.

