### PR TITLE
Fixed disappearing Snapshots

### DIFF
--- a/Sources/Vexil/Snapshots/MutableFlagGroup.swift
+++ b/Sources/Vexil/Snapshots/MutableFlagGroup.swift
@@ -14,8 +14,8 @@ public class MutableFlagGroup<Group, Root> where Group: FlagContainer, Root: Fla
 
     // MARK: - Properties
 
-    private var group: Group
-    private var snapshot: Snapshot<Root>
+    private let group: Group
+    private let snapshot: Snapshot<Root>
 
 
     // MARK: - Dynamic Member Lookup

--- a/Sources/Vexil/Snapshots/MutableFlagGroup.swift
+++ b/Sources/Vexil/Snapshots/MutableFlagGroup.swift
@@ -15,7 +15,7 @@ public class MutableFlagGroup<Group, Root> where Group: FlagContainer, Root: Fla
     // MARK: - Properties
 
     private var group: Group
-    weak private var snapshot: Snapshot<Root>?
+    private var snapshot: Snapshot<Root>
 
 
     // MARK: - Dynamic Member Lookup
@@ -45,15 +45,11 @@ public class MutableFlagGroup<Group, Root> where Group: FlagContainer, Root: Fla
     ///
     public subscript<Value> (dynamicMember dynamicMember: KeyPath<Group, Value>) -> Value where Value: FlagValue {
         get {
-            guard let snapshot = self.snapshot else { return self.group[keyPath: dynamicMember] }
-
-            return snapshot.lock.withLock {
+            return self.snapshot.lock.withLock {
                 self.group[keyPath: dynamicMember]
             }
         }
         set {
-            guard let snapshot = self.snapshot else { return }
-
             // see Snapshot.swift for how terrible this is
             return snapshot.lock.withLock {
                 _ = self.group[keyPath: dynamicMember]
@@ -65,7 +61,7 @@ public class MutableFlagGroup<Group, Root> where Group: FlagContainer, Root: Fla
 
     /// Internal initialiser used to create MutableFlagGroups for a given subgroup and snapshot
     ///
-    init (group: Group, snapshot: Snapshot<Root>?) {
+    init (group: Group, snapshot: Snapshot<Root>) {
         self.group = group
         self.snapshot = snapshot
     }

--- a/Sources/Vexil/Snapshots/Snapshot+Extensions.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+Extensions.swift
@@ -18,3 +18,17 @@ extension Snapshot: Hashable where RootGroup: Hashable {
         hasher.combine(self._rootGroup)
     }
 }
+
+extension Snapshot: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "Snapshot<\(String(describing: RootGroup.self))>("
+            + Mirror(reflecting: _rootGroup).children
+            .map { _, value -> String in
+                (value as? CustomDebugStringConvertible)?.debugDescription
+                    ?? (value as? CustomStringConvertible)?.description
+                    ?? String(describing: value)
+            }
+            .joined(separator: "; ")
+            + ")"
+    }
+}

--- a/Sources/Vexil/Snapshots/Snapshot.swift
+++ b/Sources/Vexil/Snapshots/Snapshot.swift
@@ -200,23 +200,6 @@ public class Snapshot<RootGroup> where RootGroup: FlagContainer {
 }
 
 
-// MARK: - Debugging
-
-extension Snapshot: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        return "Snapshot<\(String(describing: RootGroup.self))>("
-            + Mirror(reflecting: _rootGroup).children
-            .map { _, value -> String in
-                (value as? CustomDebugStringConvertible)?.debugDescription
-                    ?? (value as? CustomStringConvertible)?.description
-                    ?? String(describing: value)
-            }
-            .joined(separator: "; ")
-            + ")"
-    }
-}
-
-
 #if !os(Linux)
 
 typealias SnapshotValueChanged = PassthroughSubject<Void, Never>


### PR DESCRIPTION
### 📒 Description

A `MutableFlagGroup` cannot function without its `Snapshot`, so it cannot be a weak reference.

This is a leftover from the original plan where the tree was created with the Snapshot, but now `MutableFlagGroup`s are created lazily and not retained, so there is no retain cycle here.
