### PR TITLE
Added ability to create snapshots from specific sources, and to copy flag values between sources

### DIFF
--- a/Sources/Vexil/Flag.swift
+++ b/Sources/Vexil/Flag.swift
@@ -42,8 +42,7 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
 
     /// The `Flag` value. This is a calculated property based on the `FlagPole`s sources.
     public var wrappedValue: Value {
-        guard let lookup = self.decorator.lookup, let key = self.decorator.key else { return self.defaultValue }
-        return lookup.lookup(key: key) ?? self.defaultValue
+        return value(in: nil) ?? self.defaultValue
     }
 
     /// The string-based Key for this `Flag`, as calculated during `init`. This key is
@@ -122,6 +121,23 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
 
         }
     }
+
+
+    // MARK: - Lookup Support
+
+    func value (in source: FlagValueSource?) -> Value? {
+        guard let lookup = self.decorator.lookup, let key = self.decorator.key else { return self.defaultValue }
+        let value: Value? = lookup.lookup(key: key, in: source)
+
+        // if we're looking up against a specific source we return only what we get from it
+        if source != nil {
+            return value
+        }
+
+        // otherwise we're looking up on the FlagPole - which must always return a value so go back to our default
+        return value ?? self.defaultValue
+    }
+
 }
 
 

--- a/Sources/Vexil/Lookup.swift
+++ b/Sources/Vexil/Lookup.swift
@@ -18,7 +18,7 @@ import Foundation
 /// Only `FlagPole` and `Snapshot`s conform to this.
 ///
 internal protocol Lookup: AnyObject {
-    func lookup<Value> (key: String) -> Value? where Value: FlagValue
+    func lookup<Value> (key: String, in source: FlagValueSource?) -> Value? where Value: FlagValue
 
     #if !os(Linux)
     func publisher<Value> (key: String) -> AnyPublisher<Value, Never> where Value: FlagValue
@@ -33,7 +33,11 @@ extension FlagPole: Lookup {
     /// It iterates through our `FlagValueSource`s and asks each if they have a `FlagValue` for
     /// that key, returning the first non-nil value it finds.
     ///
-    func lookup<Value> (key: String) -> Value? where Value: FlagValue {
+    func lookup<Value> (key: String, in source: FlagValueSource?) -> Value? where Value: FlagValue {
+        if let source = source {
+            return source.flagValue(key: key)
+        }
+
         for source in self._sources {
             if let value: Value = source.flagValue(key: key) {
                 return value

--- a/Sources/Vexil/Snapshots/AnyFlag.swift
+++ b/Sources/Vexil/Snapshots/AnyFlag.swift
@@ -8,7 +8,7 @@
 protocol AnyFlag {
     var key: String { get }
 
-    func getFlagValue () -> Any
+    func getFlagValue (in source: FlagValueSource?) -> Any?
     func save (to source: FlagValueSource) throws
 }
 
@@ -17,8 +17,8 @@ protocol AnyFlagGroup {
 }
 
 extension Flag: AnyFlag {
-    func getFlagValue() -> Any {
-        return self.wrappedValue
+    func getFlagValue(in source: FlagValueSource?) -> Any? {
+        return value(in: source)
     }
 
     func save(to source: FlagValueSource) throws {
@@ -30,6 +30,16 @@ extension Flag: AnyFlag {
 extension FlagGroup: AnyFlagGroup {
     func allFlags () -> [AnyFlag] {
         return Mirror(reflecting: self.wrappedValue)
+            .children
+            .lazy
+            .map { $0.value }
+            .allFlags()
+    }
+}
+
+extension FlagPole: AnyFlagGroup {
+    func allFlags() -> [AnyFlag] {
+        return Mirror(reflecting: self._rootGroup)
             .children
             .lazy
             .map { $0.value }

--- a/Sources/Vexil/Snapshots/Snapshot+Lookup.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+Lookup.swift
@@ -10,7 +10,7 @@ import Combine
 #endif
 
 extension Snapshot: Lookup {
-    func lookup<Value>(key: String) -> Value? where Value: FlagValue {
+    func lookup<Value>(key: String, in source: FlagValueSource?) -> Value? where Value: FlagValue {
         self.lastAccessedKey = key
         return self.values[key] as? Value
     }

--- a/Sources/Vexil/Utilities/Locks.swift
+++ b/Sources/Vexil/Utilities/Locks.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable all
+
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -11,8 +13,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-
-// swiftlint:disable all
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 import Darwin

--- a/Tests/VexilTests/FlagPoleTests.swift
+++ b/Tests/VexilTests/FlagPoleTests.swift
@@ -17,6 +17,7 @@ final class FlagPoleTests: XCTestCase {
         XCTAssertEqual(pole._sources.count, 1)
         XCTAssertTrue(pole._sources.first as AnyObject === UserDefaults.standard)
     }
+    
 }
 
 // MARK: - Fixtures

--- a/Tests/VexilTests/FlagPoleTests.swift
+++ b/Tests/VexilTests/FlagPoleTests.swift
@@ -17,7 +17,7 @@ final class FlagPoleTests: XCTestCase {
         XCTAssertEqual(pole._sources.count, 1)
         XCTAssertTrue(pole._sources.first as AnyObject === UserDefaults.standard)
     }
-    
+
 }
 
 // MARK: - Fixtures

--- a/Tests/VexilTests/FlagValueSourceTests.swift
+++ b/Tests/VexilTests/FlagValueSourceTests.swift
@@ -58,7 +58,7 @@ final class FlagValueSourceTests: XCTestCase {
         // GIVEN two dictionaries
         let source = FlagValueDictionary([
             "test-flag": true,
-            "subgroup.test-flag": true,
+            "subgroup.test-flag": true
         ])
         let destination = FlagValueDictionary()
 

--- a/Tests/VexilTests/FlagValueSourceTests.swift
+++ b/Tests/VexilTests/FlagValueSourceTests.swift
@@ -32,28 +32,47 @@ final class FlagValueSourceTests: XCTestCase {
         XCTAssertEqual(accessedKeys.last, "test-flag")
     }
 
-    func testSourceSets () {
-        AssertNoThrow {
-            var events = [TestSetSource.Event]()
-            let source = TestSetSource {
-                events.append($0)
-            }
-
-            let pole = FlagPole(hoist: TestFlags.self, sources: [ source ])
-
-            let snapshot = pole.emptySnapshot()
-            snapshot.secondTestFlag = false
-            snapshot.testFlag = true
-
-            try pole.save(snapshot: snapshot, to: source)
-
-            XCTAssertEqual(events.count, 2)
-            XCTAssertEqual(events.first?.0, "test-flag")
-            XCTAssertEqual(events.first?.1, true)
-            XCTAssertEqual(events.last?.0, "second-test-flag")
-            XCTAssertEqual(events.last?.1, false)
+    func testSourceSets () throws {
+        var events = [TestSetSource.Event]()
+        let source = TestSetSource {
+            events.append($0)
         }
+
+        let pole = FlagPole(hoist: TestFlags.self, sources: [ source ])
+
+        let snapshot = pole.emptySnapshot()
+        snapshot.secondTestFlag = false
+        snapshot.testFlag = true
+
+        try pole.save(snapshot: snapshot, to: source)
+
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events.first?.0, "test-flag")
+        XCTAssertEqual(events.first?.1, true)
+        XCTAssertEqual(events.last?.0, "second-test-flag")
+        XCTAssertEqual(events.last?.1, false)
     }
+
+    func testSourceCopies () throws {
+
+        // GIVEN two dictionaries
+        let source = FlagValueDictionary([
+            "test-flag": true,
+            "subgroup.test-flag": true,
+        ])
+        let destination = FlagValueDictionary()
+
+        // WHEN we copy from the source to the destination
+        let pole = FlagPole(hoist: TestFlags.self, sources: [])
+        try pole.copyFlagValues(from: source, to: destination)
+
+        // THEN we expect those two dictionaries to match
+        XCTAssertEqual(destination.count, 2)
+        XCTAssertEqual(destination["test-flag"] as? Bool, true)
+        XCTAssertEqual(destination["subgroup.test-flag"] as? Bool, true)
+
+    }
+
 }
 
 
@@ -68,6 +87,15 @@ private struct TestFlags: FlagContainer {
 
     @Flag(default: true, description: "This is another test flag")
     var secondTestFlag: Bool
+
+    @FlagGroup(description: "A test subgroup")
+    var subgroup: Subgroup
+}
+
+private struct Subgroup: FlagContainer {
+
+    @Flag(default: false, description: "A test flag in a subgroup")
+    var testFlag: Bool
 
 }
 

--- a/Tests/VexilTests/SnapshotTests.swift
+++ b/Tests/VexilTests/SnapshotTests.swift
@@ -93,7 +93,7 @@ final class SnapshotTests: XCTestCase {
         let pole = FlagPole(hoist: TestFlags.self, sources: [])
         let dictionary = FlagValueDictionary([
             "top-level-flag": true,
-            "subgroup.double-subgroup.third-level-flag": true,
+            "subgroup.double-subgroup.third-level-flag": true
         ])
 
         // WHEN we take a snapshot of that source

--- a/Tests/VexilTests/SnapshotTests.swift
+++ b/Tests/VexilTests/SnapshotTests.swift
@@ -86,6 +86,27 @@ final class SnapshotTests: XCTestCase {
         XCTAssertFalse(empty.subgroup.secondLevelFlag)
         XCTAssertFalse(empty.subgroup.doubleSubgroup.thirdLevelFlag)
     }
+
+    func testCurrentSourceValueSnapshot () throws {
+
+        // GIVEN a FlagPole and a dictionary that is not a part it
+        let pole = FlagPole(hoist: TestFlags.self, sources: [])
+        let dictionary = FlagValueDictionary([
+            "top-level-flag": true,
+            "subgroup.double-subgroup.third-level-flag": true,
+        ])
+
+        // WHEN we take a snapshot of that source
+        let snapshot = pole.snapshot(of: dictionary)
+
+        // THEN we expect only the values we've changed to be true
+        XCTAssertTrue(snapshot.topLevelFlag)
+        XCTAssertFalse(snapshot.secondTestFlag)
+        XCTAssertFalse(snapshot.subgroup.secondLevelFlag)
+        XCTAssertTrue(snapshot.subgroup.doubleSubgroup.thirdLevelFlag)
+
+    }
+
 }
 
 


### PR DESCRIPTION
### 📒 Description

- Added an optional source parameter to `FlagPole.snapshot`, so its now `FlagPole.snapshot(of:)`. If the source parameter is passed in, only the flag values that exist in that source will be copied into the snapshot. If the source parameter nil or omitted the snapshot copies all values within the FlagPole.
- Added `FlagPole.copy(from:to)` to be able to flag values between two flag value sources.

### 📓 Documentation Plan

A separate PR is coming today to uplift the whole documentation site to DocC. The new options will be included then. (Reinstalling swift-doc on my new Mac is harder than I remember)

### 🗳 Test Plan

Additional tests added.

### 🧯 Source Impact

A nil default has been included with the new parameter on `FlagPole.snapshot` to ensure backwards compatibility. All other changes are additive only.

### ✅ Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary