### PR TITLE
Added support for removing/resetting all flag values in a given `FlagValueSource`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SWIFT_DOCKER_IMAGE = swift:latest
 .PHONY: test docs
 
 test:
-	docker run --rm --volume "$(shell pwd):/src" --workdir "/src" $(SWIFT_DOCKER_IMAGE) swift test --enable-test-discovery
+	docker run --rm --platform linux/amd64 -e QEMU_CPU=max --volume "$(shell pwd):/src" --workdir "/src" $(SWIFT_DOCKER_IMAGE) swift test --enable-test-discovery
 
 docs:
 	rm -f website/content/guides/*.md

--- a/Sources/Vexil/Pole.swift
+++ b/Sources/Vexil/Pole.swift
@@ -293,7 +293,7 @@ public class FlagPole<RootGroup> where RootGroup: FlagContainer {
     }
 
 
-    // MARK: - Copying Flag Values
+    // MARK: - Mutating Flag Values
 
     /// Copies the flag values from one `FlagValueSource` to another.
     ///
@@ -310,6 +310,24 @@ public class FlagPole<RootGroup> where RootGroup: FlagContainer {
     public func copyFlagValues (from source: FlagValueSource?, to destination: FlagValueSource) throws {
         let snapshot = self.snapshot(of: source)
         try self.save(snapshot: snapshot, to: destination)
+    }
+
+    /// Removes all of the flag values from the specified flag value source.
+    ///
+    /// All flag values for the given source are expected to return `nil` after this
+    /// method is called. This is useful if you want to provide a button or the capability
+    /// to "reset" a source back to its defaults, or clear any overrides in the given source.
+    ///
+    public func removeFlagValues (in source: FlagValueSource) throws {
+        let flagsInSource = FlagValueDictionary()
+        try self.copyFlagValues(from: source, to: flagsInSource)
+
+        for key in flagsInSource.keys {
+
+            // setFlagValue<Value> needs to specialise the generic, so we picked `Bool` at
+            // random so we can pass in the nil
+            try source.setFlagValue(Bool?.none, key: key)
+        }
     }
 
 }

--- a/Sources/Vexil/Sources/FlagValueDictionary+Collection.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary+Collection.swift
@@ -32,4 +32,8 @@ extension FlagValueDictionary: Collection {
         return self.storage.index(after: i)
     }
 
+    public var keys: DictionaryType.Keys {
+        return self.storage.keys
+    }
+
 }

--- a/Sources/Vexil/Sources/FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueSource.swift
@@ -25,6 +25,9 @@ public protocol FlagValueSource {
     func flagValue<Value> (key: String) -> Value? where Value: FlagValue
 
     /// And to save values – if your source does not support saving just do nothing
+    ///
+    /// It is expected if the value passed in is `nil` then the flag value would be cleared
+    ///
     func setFlagValue<Value> (_ value: Value?, key: String) throws where Value: FlagValue
 
     #if !os(Linux)

--- a/Tests/VexilTests/FlagValueSourceTests.swift
+++ b/Tests/VexilTests/FlagValueSourceTests.swift
@@ -73,6 +73,23 @@ final class FlagValueSourceTests: XCTestCase {
 
     }
 
+    func testSourceRemovesAllVales () throws {
+
+        // GIVEN a dictionary with some values
+        let source = FlagValueDictionary([
+            "test-flag": true,
+            "subgroup.test-flag": true
+        ])
+
+        // WHEN we remove all values from that source
+        let pole = FlagPole(hoist: TestFlags.self, sources: [])
+        try pole.removeFlagValues(in: source)
+
+        // THEN the source should now be empty
+        XCTAssertTrue(source.isEmpty)
+
+    }
+
 }
 
 


### PR DESCRIPTION
### 📒 Description

Added `FlagPole.removeFlagValues(in:)` to be able to remove / clear / reset all of the values in a given `FlagValueSource`. It works by discovering all of the non-nil flag keys inside the `FlagValueSource` and then setting it to `nil`.

### 📓 Documentation Plan

A separate PR is coming today to uplift the whole documentation site to DocC. The new options will be included then. (Reinstalling swift-doc on my new Mac is harder than I remember)

### 🗳 Test Plan

Additional tests were added

### 🧯 Source Impact

This change is additive only.

### ✅ Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary