### PR TITLE
Support FlagValueSources publishing changes to individual flags

### DIFF
--- a/Sources/Vexil/Pole.swift
+++ b/Sources/Vexil/Pole.swift
@@ -59,7 +59,7 @@ public class FlagPole<RootGroup> where RootGroup: FlagContainer {
             #if !os(Linux)
 
             if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
-                self.setupSnapshotPublishing(sendImmediately: true)
+                self.setupSnapshotPublishing(keys: self.allFlagKeys, sendImmediately: true)
             }
 
             #endif
@@ -103,7 +103,7 @@ public class FlagPole<RootGroup> where RootGroup: FlagContainer {
         #if !os(Linux)
 
         if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
-            self.setupSnapshotPublishing(sendImmediately: false)
+            self.setupSnapshotPublishing(keys: self.allFlagKeys, sendImmediately: false)
         }
 
         #endif
@@ -114,6 +114,20 @@ public class FlagPole<RootGroup> where RootGroup: FlagContainer {
 
     /// The "Root Group" that  contains your Flag tree/hierarchy.
     public var _rootGroup: RootGroup
+
+    /// A reference to all flags declared within the RootGroup
+    internal lazy var allFlags: [AnyFlag] = {
+        return Mirror(reflecting: self._rootGroup)
+            .children
+            .lazy
+            .map { $0.value }
+            .allFlags()
+    }()
+
+    /// A reference to all flag keys declared within the RootGroup
+    internal lazy var allFlagKeys: [String] = {
+        return self.allFlags.map { $0.key }
+    }()
 
     /// A `@dynamicMemberLookup` implementation that allows you to access the `Flag` and `FlagGroup`s contained
     /// within `self._rootGroup`
@@ -165,26 +179,35 @@ public class FlagPole<RootGroup> where RootGroup: FlagContainer {
         let snapshot = self.latestSnapshot
         if self.shouldSetupSnapshotPublishing == false {
             self.shouldSetupSnapshotPublishing = true
-            self.setupSnapshotPublishing(sendImmediately: true)
+            self.setupSnapshotPublishing(keys: self.allFlagKeys, sendImmediately: true)
         }
         return snapshot.eraseToAnyPublisher()
     }
 
     private lazy var cancellables = Set<AnyCancellable>()
 
-    private func setupSnapshotPublishing (sendImmediately: Bool) {
+    private func setupSnapshotPublishing (keys: [String], sendImmediately: Bool) {
         guard self.shouldSetupSnapshotPublishing else { return }
 
         // cancel our existing one
         self.cancellables.forEach { $0.cancel() }
         self.cancellables.removeAll()
 
-        let upstream = self._sources.compactMap { $0.valuesDidChange }
+        let upstream = self._sources
+            .compactMap { source in
+                source.valuesDidChange(keys: keys)
+                    ?? source.valuesDidChange?.map({ _ in [] }).eraseToAnyPublisher()   // backwards compatibility
+            }
 
         Publishers.MergeMany(upstream)
-            .sink { [weak self] in
+            .sink { [weak self] keys in
                 guard let self = self else { return }
-                self.latestSnapshot.send(self.snapshot())
+
+                let snapshot = Snapshot(flagPole: self, snapshot: self.latestSnapshot.value)
+                let changed = Snapshot(flagPole: self, copyingFlagValuesFrom: .pole, keys: keys.isEmpty == true ? nil : keys)
+                snapshot.merge(changed)
+
+                self.latestSnapshot.send(snapshot)
             }
             .store(in: &self.cancellables)
 

--- a/Sources/Vexil/Pole.swift
+++ b/Sources/Vexil/Pole.swift
@@ -125,8 +125,8 @@ public class FlagPole<RootGroup> where RootGroup: FlagContainer {
     }()
 
     /// A reference to all flag keys declared within the RootGroup
-    internal lazy var allFlagKeys: [String] = {
-        return self.allFlags.map { $0.key }
+    internal lazy var allFlagKeys: Set<String> = {
+        return Set(self.allFlags.map({ $0.key }))
     }()
 
     /// A `@dynamicMemberLookup` implementation that allows you to access the `Flag` and `FlagGroup`s contained
@@ -186,7 +186,7 @@ public class FlagPole<RootGroup> where RootGroup: FlagContainer {
 
     private lazy var cancellables = Set<AnyCancellable>()
 
-    private func setupSnapshotPublishing (keys: [String], sendImmediately: Bool) {
+    private func setupSnapshotPublishing (keys: Set<String>, sendImmediately: Bool) {
         guard self.shouldSetupSnapshotPublishing else { return }
 
         // cancel our existing one

--- a/Sources/Vexil/Snapshots/AnyFlag.swift
+++ b/Sources/Vexil/Snapshots/AnyFlag.swift
@@ -37,16 +37,6 @@ extension FlagGroup: AnyFlagGroup {
     }
 }
 
-extension FlagPole: AnyFlagGroup {
-    func allFlags() -> [AnyFlag] {
-        return Mirror(reflecting: self._rootGroup)
-            .children
-            .lazy
-            .map { $0.value }
-            .allFlags()
-    }
-}
-
 internal extension Sequence {
     func allFlags () -> [AnyFlag] {
         return self

--- a/Sources/Vexil/Snapshots/Snapshot+Extensions.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+Extensions.swift
@@ -21,7 +21,7 @@ extension Snapshot: Hashable where RootGroup: Hashable {
 
 extension Snapshot: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "Snapshot<\(String(describing: RootGroup.self))>("
+        return "Snapshot<\(String(describing: RootGroup.self)), \(self.values.count) overrides>("
             + Mirror(reflecting: _rootGroup).children
             .map { _, value -> String in
                 (value as? CustomDebugStringConvertible)?.debugDescription

--- a/Sources/Vexil/Snapshots/Snapshot.swift
+++ b/Sources/Vexil/Snapshots/Snapshot.swift
@@ -81,7 +81,7 @@ public class Snapshot<RootGroup> where RootGroup: FlagContainer {
 
     // MARK: - Initialisation
 
-    internal init (flagPole: FlagPole<RootGroup>, copyingFlagValuesFrom source: Source?, keys: [String]? = nil) {
+    internal init (flagPole: FlagPole<RootGroup>, copyingFlagValuesFrom source: Source?, keys: Set<String>? = nil) {
         self._rootGroup = RootGroup()
         self.decorateRootGroup(config: flagPole._configuration)
 
@@ -162,7 +162,7 @@ public class Snapshot<RootGroup> where RootGroup: FlagContainer {
             .allFlags()
     }
 
-    private func copyCurrentValues (source: Source, keys: [String]? = nil, flagPole: FlagPole<RootGroup>) {
+    private func copyCurrentValues (source: Source, keys: Set<String>? = nil, flagPole: FlagPole<RootGroup>) {
         let flagValueSource = source.flagValueSource
 
         let flags = Mirror(reflecting: flagPole._rootGroup)

--- a/Sources/Vexil/Snapshots/Snapshot.swift
+++ b/Sources/Vexil/Snapshots/Snapshot.swift
@@ -81,13 +81,19 @@ public class Snapshot<RootGroup> where RootGroup: FlagContainer {
 
     // MARK: - Initialisation
 
-    internal init (flagPole: FlagPole<RootGroup>, copyingFlagValuesFrom source: Source?) {
+    internal init (flagPole: FlagPole<RootGroup>, copyingFlagValuesFrom source: Source?, keys: [String]? = nil) {
         self._rootGroup = RootGroup()
         self.decorateRootGroup(config: flagPole._configuration)
 
         if let source = source {
-            self.copyCurrentValues(source: source, flagPole: flagPole)
+            self.copyCurrentValues(source: source, keys: keys, flagPole: flagPole)
         }
+    }
+
+    internal init (flagPole: FlagPole<RootGroup>, snapshot: Snapshot<RootGroup>) {
+        self._rootGroup = RootGroup()
+        self.decorateRootGroup(config: flagPole._configuration)
+        self.values = snapshot.values
     }
 
 
@@ -156,14 +162,15 @@ public class Snapshot<RootGroup> where RootGroup: FlagContainer {
             .allFlags()
     }
 
-    private func copyCurrentValues (source: Source, flagPole: FlagPole<RootGroup>) {
+    private func copyCurrentValues (source: Source, keys: [String]? = nil, flagPole: FlagPole<RootGroup>) {
         let flagValueSource = source.flagValueSource
 
         let flags = Mirror(reflecting: flagPole._rootGroup)
             .children
             .lazy
-            .map { $0.value }
+            .compactMap { $0.value }
             .allFlags()
+            .filter { keys == nil || keys?.contains($0.key) == true }
             .compactMap { flag -> (String, Any)? in
                 let value = flag.getFlagValue(in: flagValueSource)
 
@@ -194,6 +201,15 @@ public class Snapshot<RootGroup> where RootGroup: FlagContainer {
         }
 
         self.valuesDidChange.send()
+    }
+
+
+    // MARK: - Working with other Snapshots
+
+    internal func merge(_ other: Snapshot<RootGroup>) {
+        for value in other.values {
+            self.values.updateValue(value.value, forKey: value.key)
+        }
     }
 
 

--- a/Sources/Vexil/Sources/FlagValueDictionary+Collection.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary+Collection.swift
@@ -25,6 +25,9 @@ extension FlagValueDictionary: Collection {
             } else {
                 self.storage.removeValue(forKey: key)
             }
+            #if !os(Linux)
+            self.valueDidChange.send([ key ])
+            #endif
         }
     }
 

--- a/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
@@ -29,7 +29,7 @@ extension FlagValueDictionary: FlagValueSource {
 
     #if !os(Linux)
 
-    public func valuesDidChange(keys: [String]) -> AnyPublisher<[String], Never>? {
+    public func valuesDidChange(keys: Set<String>) -> AnyPublisher<Set<String>, Never>? {
         self.valueDidChange
             .eraseToAnyPublisher()
     }

--- a/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
@@ -29,7 +29,7 @@ extension FlagValueDictionary: FlagValueSource {
 
     #if !os(Linux)
 
-    public var valuesDidChange: AnyPublisher<Void, Never>? {
+    public func valuesDidChange(keys: [String]) -> AnyPublisher<[String], Never>? {
         self.valueDidChange
             .eraseToAnyPublisher()
     }

--- a/Sources/Vexil/Sources/FlagValueDictionary.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary.swift
@@ -27,7 +27,7 @@ open class FlagValueDictionary: Identifiable, ExpressibleByDictionaryLiteral {
     internal var storage: DictionaryType
 
     #if !os(Linux)
-    private(set) internal var valueDidChange = PassthroughSubject<[String], Never>()
+    private(set) internal var valueDidChange = PassthroughSubject<Set<String>, Never>()
     #endif
 
 

--- a/Sources/Vexil/Sources/FlagValueDictionary.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary.swift
@@ -24,16 +24,10 @@ open class FlagValueDictionary: Identifiable, ExpressibleByDictionaryLiteral {
     /// Our internal dictionary type
     public typealias DictionaryType = [String: Any]
 
-    internal var storage: DictionaryType {
-        didSet {
-            #if !os(Linux)
-            self.valueDidChange.send()
-            #endif
-        }
-    }
+    internal var storage: DictionaryType
 
     #if !os(Linux)
-    private(set) internal var valueDidChange = PassthroughSubject<Void, Never>()
+    private(set) internal var valueDidChange = PassthroughSubject<[String], Never>()
     #endif
 
 

--- a/Sources/Vexil/Sources/FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueSource.swift
@@ -30,9 +30,19 @@ public protocol FlagValueSource {
     #if !os(Linux)
 
     /// If you're running on a platform that supports Combine you can optionally support real-time
-    /// flag updates
+    /// flag updates.
+    ///
+    /// - Important: Use of this method is deprecated. Please implement `valuesDidChange(keys:)` instead
+    ///              and emit an empty array if your source does not know which keys changed.
     ///
     var valuesDidChange: AnyPublisher<Void, Never>? { get }
+
+    /// If you're running on a platform that supports Combine you can optionally support real-time
+    /// flag updates.
+    ///
+    /// If your source does not know which keys changed please emit an empty array.
+    ///
+    func valuesDidChange(keys: [String]) -> AnyPublisher<[String], Never>?
 
     #endif
 }
@@ -43,6 +53,10 @@ public protocol FlagValueSource {
 ///
 public extension FlagValueSource {
     var valuesDidChange: AnyPublisher<Void, Never>? {
+        return nil
+    }
+
+    func valuesDidChange(keys: [String]) -> AnyPublisher<[String], Never>? {
         return nil
     }
 }

--- a/Sources/Vexil/Sources/FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueSource.swift
@@ -42,7 +42,7 @@ public protocol FlagValueSource {
     ///
     /// If your source does not know which keys changed please emit an empty array.
     ///
-    func valuesDidChange(keys: [String]) -> AnyPublisher<[String], Never>?
+    func valuesDidChange(keys: Set<String>) -> AnyPublisher<Set<String>, Never>?
 
     #endif
 }
@@ -56,7 +56,7 @@ public extension FlagValueSource {
         return nil
     }
 
-    func valuesDidChange(keys: [String]) -> AnyPublisher<[String], Never>? {
+    func valuesDidChange(keys: Set<String>) -> AnyPublisher<Set<String>, Never>? {
         return nil
     }
 }

--- a/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
@@ -47,14 +47,14 @@ extension NSUbiquitousKeyValueStore: FlagValueSource {
     private static let didChangeInternallyNotification = NSNotification.Name(rawValue: "NSUbiquitousKeyValueStore.didChangeExternallyNotification")
 
     /// A Publisher that emits events when the flag values it manages changes
-    public var valuesDidChange: AnyPublisher<Void, Never>? {
+    public func valuesDidChange(keys: Set<String>) -> AnyPublisher<Set<String>, Never>? {
         return Publishers.Merge(
                 NotificationCenter.default.publisher(for: Self.didChangeExternallyNotification, object: self).map { _ in () },
                 NotificationCenter.default.publisher(for: Self.didChangeInternallyNotification, object: self).map { _ in () }
             )
             .map { _ in
                 self.synchronize()
-                return ()
+                return []
             }
             .eraseToAnyPublisher()
     }

--- a/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
@@ -45,22 +45,23 @@ extension UserDefaults: FlagValueSource {
     #if os(watchOS)
 
     /// A Publisher that emits events when the flag values it manages changes
-    public var valuesDidChange: AnyPublisher<Void, Never>? {
+    public func valuesDidChange(keys: Set<String>) -> AnyPublisher<Set<String>, Never>? {
         return NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
             .filter { ($0.object as AnyObject) === self }
-            .map { _ in () }
+            .map { _ in [] }
             .eraseToAnyPublisher()
     }
 
     #elseif !os(Linux)
 
-    public var valuesDidChange: AnyPublisher<Void, Never>? {
+    public func valuesDidChange(keys: Set<String>) -> AnyPublisher<Set<String>, Never>? {
         return Publishers.Merge (
             NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
                 .filter { ($0.object as AnyObject) === self }
                 .map { _ in () },
             NotificationCenter.default.publisher(for: ApplicationDidBecomeActive).map { _ in () }
         )
+            .map { _ in [] }
             .eraseToAnyPublisher()
     }
 

--- a/Tests/VexilTests/FlagValueDictionaryTests.swift
+++ b/Tests/VexilTests/FlagValueDictionaryTests.swift
@@ -47,6 +47,7 @@ final class FlagValueDictionaryTests: XCTestCase {
 
     func testPublishesValues () {
         let expectation = self.expectation(description: "publisher")
+        expectation.expectedFulfillmentCount = 3
 
         let source = FlagValueDictionary()
         let flagPole = FlagPole(hoist: TestFlags.self, sources: [ source ])
@@ -55,9 +56,7 @@ final class FlagValueDictionaryTests: XCTestCase {
         let cancellable = flagPole.publisher
             .sink { snapshot in
                 snapshots.append(snapshot)
-                if snapshots.count == 3 {
-                    expectation.fulfill()
-                }
+                expectation.fulfill()
             }
 
         source["top-level-flag"] = true

--- a/Tests/VexilTests/PublisherTests.swift
+++ b/Tests/VexilTests/PublisherTests.swift
@@ -223,9 +223,9 @@ private struct TestFlags: FlagContainer {
 
 private final class TestSource: FlagValueSource {
     var name = "Test Source"
-    var subject = PassthroughSubject<[String], Never>()
+    var subject = PassthroughSubject<Set<String>, Never>()
 
-    var requestedKeys: [String] = []
+    var requestedKeys: Set<String> = []
 
     init () {}
 
@@ -236,7 +236,7 @@ private final class TestSource: FlagValueSource {
     func setFlagValue<Value>(_ value: Value?, key: String) throws where Value: FlagValue {
     }
 
-    func valuesDidChange(keys: [String]) -> AnyPublisher<[String], Never>? {
+    func valuesDidChange(keys: Set<String>) -> AnyPublisher<Set<String>, Never>? {
         self.requestedKeys = keys
         return subject.eraseToAnyPublisher()
     }


### PR DESCRIPTION
### 📒 Description

Added a new `FlagValueSource.valuesDidChange(keys:)` method that should return an `AnyPublisher<Set<String>, Never>`. It is preferred over the existing `valuesDidChange` property.

Flag Value Sources that are able to tell which of their flag values have changed at any one time can implement this method instead of the `valuesDidChangeProperty` and emit a set of the keys that have changed.

This allows for a performance boost with larger FlagContainers. Previously every time a snapshot was calculated we would walk the entire flag tree and request the value of each flag from the source hierarchy. Now we only request the value of the flags that we know have changed.

### 📓 Documentation Plan

A separate PR is coming today to uplift the whole documentation site to DocC. The new options will be included then. (Reinstalling swift-doc on my new Mac is harder than I remember)

### 🗳 Test Plan

New unit tests have been added to cover the additional and changed functionality and ensure backwards compatibility was maintained.

### 🧯 Source Impact

It soft-deprecates the `FlagValueSource.valuesDidChange` property but full backwards compatibility is maintained. It makes some internal changes to how we calculate snapshots, but does not affect the output.

### ✅ Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary