### PR TITLE
Added support for the standard Swift default setter syntax

### DIFF
--- a/Sources/Vexil/Flag.swift
+++ b/Sources/Vexil/Flag.swift
@@ -85,6 +85,30 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
         self.info = info
     }
 
+    /// Initialises a new `Flag` with the supplied info.
+    ///
+    /// You must at least a `description` of the flag and specify the default value
+    ///
+    /// ```swift
+    /// @Flag(description: "This is a test flag. Isn't it nice?")
+    /// var myFlag: Bool = false
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - name:               An optional display name to give the flag. Only visible in flag editors like Vexillographer. Default is to calculate one based on the property name.
+    ///   - codingKeyStrategy:  An optional strategy to use when calculating the key name. The default is to use the `FlagPole`s strategy.
+    ///   - description:        A description of this flag. Used in flag editors like Vexillographer, and also for future developer context.
+    ///                         You can also specify `.hidden` to hide this flag from Vexillographer.
+    ///
+    public init (wrappedValue: Value, name: String? = nil, codingKeyStrategy: CodingKeyStrategy = .default, description: FlagInfo) {
+        self.codingKeyStrategy = codingKeyStrategy
+        self.defaultValue = wrappedValue
+
+        var info = description
+        info.name = name
+        self.info = info
+    }
+
 
     // MARK: - Decorated Conformance
 

--- a/Tests/VexilTests/EquatableTests.swift
+++ b/Tests/VexilTests/EquatableTests.swift
@@ -150,8 +150,8 @@ private struct TestFlags: FlagContainer, Equatable {
     @Flag(default: false, description: "Top level test flag")
     var topLevelFlag: Bool
 
-    @Flag(default: false, description: "Second test flag")
-    var secondTestFlag: Bool
+    @Flag(description: "Second test flag")
+    var secondTestFlag = false
 
     @FlagGroup(description: "Subgroup of test flags")
     var subgroup: SubgroupFlags
@@ -170,7 +170,7 @@ private struct SubgroupFlags: FlagContainer, Equatable {
 
 private struct DoubleSubgroupFlags: FlagContainer, Equatable {
 
-    @Flag(default: false, description: "Third level test flag")
-    var thirdLevelFlag: Bool
+    @Flag(description: "Third level test flag")
+    var thirdLevelFlag = false
 
 }

--- a/Tests/VexilTests/FlagValueDictionaryTests.swift
+++ b/Tests/VexilTests/FlagValueDictionaryTests.swift
@@ -88,8 +88,8 @@ private struct TestFlags: FlagContainer {
     @FlagGroup(description: "Test 1")
     var oneFlagGroup: OneFlags
 
-    @Flag(default: false, description: "Top level test flag")
-    var topLevelFlag: Bool
+    @Flag(description: "Top level test flag")
+    var topLevelFlag: Bool = false
 
 }
 


### PR DESCRIPTION
### 📒 Description

This PR adds support for the normal Swift default property value setter, eg:

```swift
@Flag(description: "This is a demo")
var demo = false
```

Unlike the equivalent change in [Swift Argument Parser](https://github.com/apple/swift-argument-parser) we're not removing support for the existing specific `default:` parameter if people wish to use that instead.