### PR TITLE
Workflow fixes

### DIFF
--- a/.github/scripts/generate-docs.sh
+++ b/.github/scripts/generate-docs.sh
@@ -19,7 +19,8 @@ WORKING="docs"
 # Build our docs
 xcodebuild docbuild \
     -scheme "${SCHEME}" \
-    -derivedDataPath "${DERIVED_DATA}"
+    -derivedDataPath "${DERIVED_DATA}" \
+    -destination "platform=macOS, name=Any Mac"
 
 # Make sure they exist
 if [ ! -d "${VEXIL_DOCCARCHIVE}" ]; then

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-11.0
     strategy:
       matrix:
-        xcode: [ "11.7", "12.2", "12.3", "12.4", "12.5" ]
+        xcode: [ "11.7", "12.4", "12.5", "12.5.1" ]
 
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: [ "5.2.5", "5.3", "5.3.1", "5.3.2", "5.3.3", "5.4.1" ]
+        swift: [ "5.2.5", "5.3", "5.3.1", "5.3.2", "5.3.3", "5.4.1", "5.4.2" ]
         os: [ amazonlinux2, bionic, centos7, centos8, focal, xenial ]
     
     container:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-11.0
     strategy:
       matrix:
-        xcode: [ "11.7", "12.2", "12.3", "12.4", "12.5" ]
+        xcode: [ "11.7", "12.4", "12.5", "12.5.1" ]
 
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer

--- a/.github/workflows/tvos-tests.yml
+++ b/.github/workflows/tvos-tests.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-11.0
     strategy:
       matrix:
-        xcode: [ "11.7", "12.2", "12.3", "12.4", "12.5" ]
+        xcode: [ "11.7", "12.4", "12.5", "12.5.1" ]
 
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer

--- a/.github/workflows/watchos-tests.yml
+++ b/.github/workflows/watchos-tests.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-11.0
     strategy:
       matrix:
-        xcode: [ "11.7", "12.2", "12.3", "12.4", "12.5" ]
+        xcode: [ "11.7", "12.4", "12.5", "12.5.1" ]
 
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer


### PR DESCRIPTION
### 📒 Description

- Added a `-destination` argument to our `xcodebuild docbuild` command
- Added support for Xcode 12.5.1 on all platforms with macOS 11 runners
- Added support for Swift 5.4.2 on Linux
- Dropped support for Xcode 12.2 from all platforms on macOS 11 runners (macOS 10.15 runners still support it)
- Dropped support for Xcode 12.3 from all platforms on macOS 11 runners (macOS 10.15 runners still support it)