### PR TITLE
Updated workflows to reflect the release of Swift 5.5 and Xcode 13.0

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -13,28 +13,28 @@ on:
       - '**/*.swift'
     
 jobs:
-  build-ios-beta:
-    name: iOS Tests - Xcode Betas
-    runs-on: macos-11.0
-    strategy:
-      matrix:
-        xcode: [ "13.0" ]
+  # build-ios-beta:
+  #   name: iOS Tests - Xcode Betas
+  #   runs-on: macos-11.0
+  #   strategy:
+  #     matrix:
+  #       xcode: [ "13.0" ]
 
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+  #   env:
+  #     DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build and Test
-        run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Build and Test
+  #       run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
 
   build-ios-macos-11:
     name: iOS Tests - macOS 11
     runs-on: macos-11.0
     strategy:
       matrix:
-        xcode: [ "11.7", "12.4", "12.5", "12.5.1" ]
+        xcode: [ "11.7", "12.4", "12.5.1", "13.0" ]
 
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: [ "5.2.5", "5.3", "5.3.1", "5.3.2", "5.3.3", "5.4.1", "5.4.2" ]
+        swift: [ "5.2.5", "5.3", "5.3.1", "5.3.2", "5.3.3", "5.4.1", "5.4.2", "5.5.0" ]
         os: [ amazonlinux2, bionic, centos7, centos8, focal, xenial ]
     
     container:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -13,28 +13,28 @@ on:
       - '**/*.swift'
     
 jobs:
-  build-macos-beta:
-    name: macOS Tests - Xcode Betas
-    runs-on: macos-11.0
-    strategy:
-      matrix:
-        xcode: [ "13.0" ]
+  # build-macos-beta:
+  #   name: macOS Tests - Xcode Betas
+  #   runs-on: macos-11.0
+  #   strategy:
+  #     matrix:
+  #       xcode: [ "13.0" ]
 
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+  #   env:
+  #     DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build and Test
-        run: swift test
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Build and Test
+  #       run: swift test
 
   build-macos-macos-11:
     name: macOS Tests - macOS 11
     runs-on: macos-11.0
     strategy:
       matrix:
-        xcode: [ "11.7", "12.4", "12.5", "12.5.1" ]
+        xcode: [ "11.7", "12.4", "12.5.1", "13.0" ]
 
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer

--- a/.github/workflows/tvos-tests.yml
+++ b/.github/workflows/tvos-tests.yml
@@ -13,28 +13,28 @@ on:
       - '**/*.swift'
     
 jobs:
-  build-tvos-beta:
-    name: tvOS Tests - Xcode Betas
-    runs-on: macos-11.0
-    strategy:
-      matrix:
-        xcode: [ "13.0" ]
+  # build-tvos-beta:
+  #   name: tvOS Tests - Xcode Betas
+  #   runs-on: macos-11.0
+  #   strategy:
+  #     matrix:
+  #       xcode: [ "13.0" ]
 
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+  #   env:
+  #     DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build and Test
-        run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=tvOS Simulator,name=Apple TV 4K"
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Build and Test
+  #       run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=tvOS Simulator,name=Apple TV 4K"
 
   build-tvos-macos-11:
     name: tvOS Tests - macOS 11
     runs-on: macos-11.0
     strategy:
       matrix:
-        xcode: [ "11.7", "12.4", "12.5", "12.5.1" ]
+        xcode: [ "11.7", "12.4", "12.5.1", "13.0" ]
 
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer

--- a/.github/workflows/watchos-tests.yml
+++ b/.github/workflows/watchos-tests.yml
@@ -13,28 +13,28 @@ on:
       - '**/*.swift'
     
 jobs:
-  build-watchos-beta:
-    name: watchOS Build - Xcode Betas
-    runs-on: macos-11.0
-    strategy:
-      matrix:
-        xcode: [ "13.0" ]
+  # build-watchos-beta:
+  #   name: watchOS Build - Xcode Betas
+  #   runs-on: macos-11.0
+  #   strategy:
+  #     matrix:
+  #       xcode: [ "13.0" ]
 
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+  #   env:
+  #     DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build and Test
-        run: swift package generate-xcodeproj && xcrun xcodebuild build -scheme "Vexil-Package" -destination "generic/platform=watchos"
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Build and Test
+  #       run: swift package generate-xcodeproj && xcrun xcodebuild build -scheme "Vexil-Package" -destination "generic/platform=watchos"
 
   build-watchos-macos-11:
     name: watchOS Build - macOS 11
     runs-on: macos-11.0
     strategy:
       matrix:
-        xcode: [ "11.7", "12.4", "12.5", "12.5.1" ]
+        xcode: [ "11.7", "12.4", "12.5.1", "13.0" ]
 
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer


### PR DESCRIPTION
### 📒 Description

This PR:

- Drops support for Xcode 12.5, which will no longer be supported by GitHub from next week (Xcode 12.5.1 will still be supported)
- Makes Xcode 13.0 checks required
- Added Linux tests for Swift 5.5