### PR TITLE
Skip workflow jobs using path-filter instead of the built-in filter

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -8,6 +8,7 @@ on:
     
 jobs:
   check-changes:
+    name: Check for Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -19,6 +20,10 @@ jobs:
           changed:
             - '.github/workflows/ios-tests.yml'
             - '**/*.swift'
+
+  #############
+  # iOS Betas #
+  #############
 
   # build-ios-beta:
   #   name: iOS Tests - Xcode Betas
@@ -39,9 +44,15 @@ jobs:
   #       run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
   #       if: ${{ needs.check-changes.outputs.changed == 'true' }}
 
-  build-ios-macos-11:
-    name: iOS Tests - macOS 11
+  #####################
+  # macOS 11 Versions #
+  #####################
+
+  build-ios-macos-11-matrix:
+    name: iOS Metrix - macOS 11
     runs-on: macos-11.0
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     strategy:
       matrix:
         xcode: [ "11.7", "12.4", "12.5.1", "13.0" ]
@@ -52,14 +63,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        if: ${{ needs.check-changes.outputs.changed == 'true' }}
       - name: Build and Test
         run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
-        if: ${{ needs.check-changes.outputs.changed == 'true' }}
 
-  build-ios-macos-10_15:
-    name: iOS Tests - macOS 10.15
+  build-ios-macos-11:
+    runs-on: ubuntu-latest
+    name: iOS Tests - macOS 11
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: build-ios-macos-11-matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build-ios-macos-11-matrix.result == 'failure' }}
+        run: exit 1
+
+  ########################
+  # macOS 10.15 Versions #
+  ########################
+
+  build-ios-macos-10_15-matrix:
+    name: iOS Matrix - macOS 10.15
     runs-on: macos-10.15
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     strategy:
       matrix:
         xcode: [ "11.7", "12", "12.1", "12.2", "12.3", "12.4" ]
@@ -70,7 +95,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        if: ${{ needs.check-changes.outputs.changed == 'true' }}
       - name: Build and Test
         run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
-        if: ${{ needs.check-changes.outputs.changed == 'true' }}
+
+  build-ios-macos-10_15:
+    runs-on: ubuntu-latest
+    name: iOS Tests - macOS 10.15
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: build-ios-macos-10_15-matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build-ios-macos-11-matrix.result == 'failure' }}
+        run: exit 1

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -8,6 +8,7 @@ on:
     
 jobs:
   check-changes:
+    name: Check for Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -20,10 +21,15 @@ jobs:
             - '.github/workflows/linux-tests.yml'
             - '**/*.swift'
 
-  test:
-    name: Linux Tests
+  #########
+  # Linux #
+  #########
+
+  matrix:
+    name: Linux Matrix
     runs-on: ubuntu-latest
     if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     strategy:
       matrix:
         swift: [ "5.2.5", "5.3", "5.3.1", "5.3.2", "5.3.3", "5.4.1", "5.4.2", "5.5.0" ]
@@ -37,3 +43,13 @@ jobs:
         uses: actions/checkout@v1
       - name: Build and Test
         run: swift test --enable-test-discovery
+
+  test:
+    runs-on: ubuntu-latest
+    name: Linux Tests
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.matrix.result == 'failure' }}
+        run: exit 1

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -8,6 +8,7 @@ on:
     
 jobs:
   check-changes:
+    name: Check for Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -20,10 +21,15 @@ jobs:
             - '.github/workflows/macos-tests.yml'
             - '**/*.swift'
 
+  ###############
+  # macOS Betas #
+  ###############
+
   # build-macos-beta:
   #   name: macOS Tests - Xcode Betas
   #   runs-on: macos-11.0
   #   if: ${{ needs.check-changes.outputs.changed == 'true' }}
+  #   needs: check-changes
   #   strategy:
   #     matrix:
   #       xcode: [ "13.0" ]
@@ -37,10 +43,15 @@ jobs:
   #     - name: Build and Test
   #       run: swift test
 
-  build-macos-macos-11:
-    name: macOS Tests - macOS 11
+  ############
+  # macOS 11 #
+  ############
+
+  build-macos-macos-11-matrix:
+    name: macOS Matrix - macOS 11
     runs-on: macos-11.0
     if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     strategy:
       matrix:
         xcode: [ "11.7", "12.4", "12.5.1", "13.0" ]
@@ -54,10 +65,25 @@ jobs:
       - name: Build and Test
         run: swift test
 
-  build-macos-macos-10_15:
-    name: macOS Tests - macOS 10.15
+  build-macos-macos-11:
+    runs-on: ubuntu-latest
+    name: macOS Tests - macOS 11
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: build-macos-macos-11-matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build-macos-macos-11-matrix.result == 'failure' }}
+        run: exit 1
+
+  ###############
+  # macOS 10.15 #
+  ###############
+
+  build-macos-macos-10_15-matrix:
+    name: macOS Matrix - macOS 10.15
     runs-on: macos-10.15
     if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     strategy:
       matrix:
         xcode: [ "11.7", "12", "12.1", "12.2", "12.3", "12.4" ]
@@ -69,4 +95,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build and Test
-        run: swift test
+        run: swift
+        
+  build-macos-macos-10_15:
+    runs-on: ubuntu-latest
+    name: macOS Tests - macOS 10.15
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: build-macos-macos-10_15-matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build-macos-macos-10_15-matrix.result == 'failure' }}
+        run: exit 1

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   check-changes:
+    name: Check for Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -22,6 +23,7 @@ jobs:
   SwiftLint:
     runs-on: ubuntu-latest
     if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     steps:
       - uses: actions/checkout@v1
       - name: "🧹 SwiftLint changed files"

--- a/.github/workflows/tvos-tests.yml
+++ b/.github/workflows/tvos-tests.yml
@@ -8,6 +8,7 @@ on:
     
 jobs:
   check-changes:
+    name: Check for Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -20,10 +21,15 @@ jobs:
             - '.github/workflows/tvos-tests.yml'
             - '**/*.swift'
 
+  ##############
+  # tvOS Betas #
+  ##############
+
   # build-tvos-beta:
   #   name: tvOS Tests - Xcode Betas
   #   runs-on: macos-11.0
   #   if: ${{ needs.check-changes.outputs.changed == 'true' }}
+  #   needs: check-changes
   #   strategy:
   #     matrix:
   #       xcode: [ "13.0" ]
@@ -37,10 +43,15 @@ jobs:
   #     - name: Build and Test
   #       run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=tvOS Simulator,name=Apple TV 4K"
 
-  build-tvos-macos-11:
-    name: tvOS Tests - macOS 11
+  #####################
+  # macOS 11 Versions #
+  #####################
+
+  build-tvos-macos-11-matrix:
+    name: tvOS Matrix - macOS 11
     runs-on: macos-11.0
     if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     strategy:
       matrix:
         xcode: [ "11.7", "12.4", "12.5.1", "13.0" ]
@@ -54,10 +65,25 @@ jobs:
       - name: Build and Test
         run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=tvOS Simulator,name=Apple TV 4K"
 
-  build-tvos-macos-10_15:
-    name: tvOS Tests - macOS 10.15
+  build-tvos-macos-11:
+    runs-on: ubuntu-latest
+    name: tvOS Tests - macOS 11
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: build-tvos-macos-11-matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build-tvos-macos-11-matrix.result == 'failure' }}
+        run: exit 1
+
+  ########################
+  # macOS 10.15 Versions #
+  ########################
+
+  build-tvos-macos-10_15-matrix:
+    name: tvOS Matrix - macOS 10.15
     runs-on: macos-10.15
     if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     strategy:
       matrix:
         xcode: [ "11.7", "12", "12.1", "12.2", "12.3", "12.4" ]
@@ -70,3 +96,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Build and Test
         run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=tvOS Simulator,name=Apple TV 4K"
+
+  build-tvos-macos-10_15:
+    runs-on: ubuntu-latest
+    name: tvOS Tests - macOS 10.15
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: build-tvos-macos-10_15-matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build-tvos-macos-10_15-matrix.result == 'failure' }}
+        run: exit 1

--- a/.github/workflows/watchos-tests.yml
+++ b/.github/workflows/watchos-tests.yml
@@ -8,6 +8,7 @@ on:
     
 jobs:
   check-changes:
+    name: Check for Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
@@ -20,10 +21,15 @@ jobs:
             - '.github/workflows/watchos-tests.yml'
             - '**/*.swift'
 
+  #################
+  # watchOS Betas #
+  #################
+
   # build-watchos-beta:
   #   name: watchOS Build - Xcode Betas
   #   runs-on: macos-11.0
   #   if: ${{ needs.check-changes.outputs.changed == 'true' }}
+  #   needs: check-changes
   #   strategy:
   #     matrix:
   #       xcode: [ "13.0" ]
@@ -37,10 +43,15 @@ jobs:
   #     - name: Build and Test
   #       run: swift package generate-xcodeproj && xcrun xcodebuild build -scheme "Vexil-Package" -destination "generic/platform=watchos"
 
-  build-watchos-macos-11:
-    name: watchOS Build - macOS 11
+  #####################
+  # macOS 11 Versions #
+  #####################
+
+  build-watchos-macos-11-matrix:
+    name: watchOS Matrix - macOS 11
     runs-on: macos-11.0
     if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     strategy:
       matrix:
         xcode: [ "11.7", "12.4", "12.5.1", "13.0" ]
@@ -54,10 +65,25 @@ jobs:
       - name: Build and Test
         run: swift package generate-xcodeproj && xcrun xcodebuild build -scheme "Vexil-Package" -destination "generic/platform=watchos"
 
-  build-watchos-macos-10_15:
-    name: watchOS Build - macOS 10.15
+  build-watchos-macos-11:
+    runs-on: ubuntu-latest
+    name: watchOS Build - macOS 11
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: build-watchos-macos-11-matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build-watchos-macos-11-matrix.result == 'failure' }}
+        run: exit 1
+
+  ########################
+  # macOS 10.15 Versions #
+  ########################
+
+  build-watchos-macos-10_15-matrix:
+    name: watchOS Matrix - macOS 10.15
     runs-on: macos-10.15
     if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: check-changes
     strategy:
       matrix:
         xcode: [ "11.7", "12", "12.1", "12.2", "12.3", "12.4" ]
@@ -70,3 +96,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Build and Test
         run: swift package generate-xcodeproj && xcrun xcodebuild build -scheme "Vexil-Package" -destination "generic/platform=watchos"
+
+  build-watchos-macos-10_15:
+    runs-on: ubuntu-latest
+    name: watchOS Build - macOS 10.15
+    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    needs: build-watchos-macos-10_15-matrix
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build-watchos-macos-10_15-matrix.result == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
### 📒 Description

This means that skipped workflows can still satisfy required checks.