### PR TITLE
Target generic macOS for documentation build

### DIFF
--- a/.github/scripts/generate-docs.sh
+++ b/.github/scripts/generate-docs.sh
@@ -20,7 +20,7 @@ WORKING="docs"
 xcodebuild docbuild \
     -scheme "${SCHEME}" \
     -derivedDataPath "${DERIVED_DATA}" \
-    -destination "platform=macOS,name=Any Mac"
+    -destination "generic/platform=macOS"
 
 # Make sure they exist
 if [ ! -d "${VEXIL_DOCCARCHIVE}" ]; then


### PR DESCRIPTION
### 📒 Description

Updates our destination to be `generic/platform=macOS` when building documentation.