### PR TITLE
Always run unit tests on `push`

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -10,6 +10,7 @@ jobs:
   check-changes:
     name: Check for Changes
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
@@ -28,7 +29,7 @@ jobs:
   # build-ios-beta:
   #   name: iOS Tests - Xcode Betas
   #   runs-on: macos-11.0
-  #   if: ${{ needs.check-changes.outputs.changed == 'true' }}
+  #   if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
   #   strategy:
   #     matrix:
   #       xcode: [ "13.0" ]
@@ -39,10 +40,10 @@ jobs:
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v2
-  #       if: ${{ needs.check-changes.outputs.changed == 'true' }}
+  #       if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
   #     - name: Build and Test
   #       run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
-  #       if: ${{ needs.check-changes.outputs.changed == 'true' }}
+  #       if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
 
   #####################
   # macOS 11 Versions #
@@ -51,7 +52,7 @@ jobs:
   build-ios-macos-11-matrix:
     name: iOS Metrix - macOS 11
     runs-on: macos-11.0
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     strategy:
       matrix:
@@ -69,7 +70,7 @@ jobs:
   build-ios-macos-11:
     runs-on: ubuntu-latest
     name: iOS Tests - macOS 11
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: build-ios-macos-11-matrix
     steps:
       - name: Check build matrix status
@@ -83,7 +84,7 @@ jobs:
   build-ios-macos-10_15-matrix:
     name: iOS Matrix - macOS 10.15
     runs-on: macos-10.15
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     strategy:
       matrix:
@@ -101,7 +102,7 @@ jobs:
   build-ios-macos-10_15:
     runs-on: ubuntu-latest
     name: iOS Tests - macOS 10.15
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: build-ios-macos-10_15-matrix
     steps:
       - name: Check build matrix status

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -10,6 +10,7 @@ jobs:
   check-changes:
     name: Check for Changes
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
@@ -28,7 +29,7 @@ jobs:
   matrix:
     name: Linux Matrix
     runs-on: ubuntu-latest
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     strategy:
       matrix:
@@ -47,7 +48,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Linux Tests
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: matrix
     steps:
       - name: Check build matrix status

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -10,6 +10,7 @@ jobs:
   check-changes:
     name: Check for Changes
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
@@ -28,7 +29,7 @@ jobs:
   # build-macos-beta:
   #   name: macOS Tests - Xcode Betas
   #   runs-on: macos-11.0
-  #   if: ${{ needs.check-changes.outputs.changed == 'true' }}
+  #   if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
   #   needs: check-changes
   #   strategy:
   #     matrix:
@@ -50,7 +51,7 @@ jobs:
   build-macos-macos-11-matrix:
     name: macOS Matrix - macOS 11
     runs-on: macos-11.0
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     strategy:
       matrix:
@@ -68,7 +69,7 @@ jobs:
   build-macos-macos-11:
     runs-on: ubuntu-latest
     name: macOS Tests - macOS 11
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: build-macos-macos-11-matrix
     steps:
       - name: Check build matrix status
@@ -82,7 +83,7 @@ jobs:
   build-macos-macos-10_15-matrix:
     name: macOS Matrix - macOS 10.15
     runs-on: macos-10.15
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     strategy:
       matrix:
@@ -100,7 +101,7 @@ jobs:
   build-macos-macos-10_15:
     runs-on: ubuntu-latest
     name: macOS Tests - macOS 10.15
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: build-macos-macos-10_15-matrix
     steps:
       - name: Check build matrix status

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -8,6 +8,7 @@ jobs:
   check-changes:
     name: Check for Changes
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
@@ -22,7 +23,7 @@ jobs:
 
   SwiftLint:
     runs-on: ubuntu-latest
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/tvos-tests.yml
+++ b/.github/workflows/tvos-tests.yml
@@ -10,6 +10,7 @@ jobs:
   check-changes:
     name: Check for Changes
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
@@ -28,7 +29,7 @@ jobs:
   # build-tvos-beta:
   #   name: tvOS Tests - Xcode Betas
   #   runs-on: macos-11.0
-  #   if: ${{ needs.check-changes.outputs.changed == 'true' }}
+  #   if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
   #   needs: check-changes
   #   strategy:
   #     matrix:
@@ -50,7 +51,7 @@ jobs:
   build-tvos-macos-11-matrix:
     name: tvOS Matrix - macOS 11
     runs-on: macos-11.0
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     strategy:
       matrix:
@@ -68,7 +69,7 @@ jobs:
   build-tvos-macos-11:
     runs-on: ubuntu-latest
     name: tvOS Tests - macOS 11
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: build-tvos-macos-11-matrix
     steps:
       - name: Check build matrix status
@@ -82,7 +83,7 @@ jobs:
   build-tvos-macos-10_15-matrix:
     name: tvOS Matrix - macOS 10.15
     runs-on: macos-10.15
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     strategy:
       matrix:
@@ -100,7 +101,7 @@ jobs:
   build-tvos-macos-10_15:
     runs-on: ubuntu-latest
     name: tvOS Tests - macOS 10.15
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: build-tvos-macos-10_15-matrix
     steps:
       - name: Check build matrix status

--- a/.github/workflows/watchos-tests.yml
+++ b/.github/workflows/watchos-tests.yml
@@ -10,6 +10,7 @@ jobs:
   check-changes:
     name: Check for Changes
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
@@ -28,7 +29,7 @@ jobs:
   # build-watchos-beta:
   #   name: watchOS Build - Xcode Betas
   #   runs-on: macos-11.0
-  #   if: ${{ needs.check-changes.outputs.changed == 'true' }}
+  #   if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
   #   needs: check-changes
   #   strategy:
   #     matrix:
@@ -50,7 +51,7 @@ jobs:
   build-watchos-macos-11-matrix:
     name: watchOS Matrix - macOS 11
     runs-on: macos-11.0
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     strategy:
       matrix:
@@ -68,7 +69,7 @@ jobs:
   build-watchos-macos-11:
     runs-on: ubuntu-latest
     name: watchOS Build - macOS 11
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: build-watchos-macos-11-matrix
     steps:
       - name: Check build matrix status
@@ -82,7 +83,7 @@ jobs:
   build-watchos-macos-10_15-matrix:
     name: watchOS Matrix - macOS 10.15
     runs-on: macos-10.15
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: check-changes
     strategy:
       matrix:
@@ -100,7 +101,7 @@ jobs:
   build-watchos-macos-10_15:
     runs-on: ubuntu-latest
     name: watchOS Build - macOS 10.15
-    if: ${{ needs.check-changes.outputs.changed == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.check-changes.outputs.changed == 'true' }}
     needs: build-watchos-macos-10_15-matrix
     steps:
       - name: Check build matrix status


### PR DESCRIPTION
### 📒 Description

Fixes workflow where the path filtering was attempted after merge and the unit tests jobs skipped.