### PR TITLE
Added diagnostics for flag resolution and real-time updates

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ disabled_rules:
   - type_name
   - vertical_whitespace
   - identifier_name
+  - let_var_whitespace
 
 opt_in_rules:
   - anyobject_protocol
@@ -66,6 +67,10 @@ cyclomatic_complexity:
 line_length:
   ignores_function_declarations: true
   warning: 180
+
+file_length:
+  warning: 800
+  error: 1500
 
 identifier_name:
   excluded: [id, x, y, z, r, g, b, a, i, j, k, cx, cy, dx, dy, _rootGroup]

--- a/Sources/Vexil/Diagnostics.swift
+++ b/Sources/Vexil/Diagnostics.swift
@@ -1,0 +1,93 @@
+//
+//  Diagnostics.swift
+//  Vexil
+//
+//  Created by Rob Amos on 12/12/21.
+//
+
+import Foundation
+
+/// A diagnostic that is returned by `FlagPole.makeDiagnostics()`
+///
+public enum FlagPoleDiagnostic: Equatable {
+
+    // MARK: - Cases
+
+    case currentValue(key: String, value: BoxedFlagValue, resolvedBy: String?)
+    case changedValue(key: String, value: BoxedFlagValue, resolvedBy: String?, changedBy: String?)
+
+}
+
+
+// MARK: - Initialisation
+
+extension Array where Element == FlagPoleDiagnostic {
+
+    /// Creates diagnostic cases from an initial snapshot
+    init<Root> (current: Snapshot<Root>) where Root: FlagContainer {
+        self = current.values
+            .sorted(by: { $0.key < $1.key })
+            .compactMap { element -> FlagPoleDiagnostic? in
+                guard let value = element.value.boxed else {
+                    return nil
+                }
+                return .currentValue(key: element.key, value: value, resolvedBy: element.value.source)
+            }
+
+    }
+
+    /// Creates diagnostic cases from a changed snapshot
+    init<Root> (changed: Snapshot<Root>, sources: [String]?) where Root: FlagContainer {
+        let changedBy: String?
+        if let sources = sources {
+            changedBy = Set(sources).sorted().joined(separator: ", ")
+        } else {
+            changedBy = nil
+        }
+
+        self = changed.values
+            .sorted(by: { $0.key < $1.key })
+            .compactMap { element -> FlagPoleDiagnostic? in
+                guard let value = element.value.boxed else {
+                    return nil
+                }
+                return .changedValue(key: element.key, value: value, resolvedBy: element.value.source, changedBy: changedBy)
+            }
+
+    }
+
+}
+
+
+// MARK: - Debugging
+
+extension FlagPoleDiagnostic: CustomDebugStringConvertible {
+
+    public var debugDescription: String {
+        switch self {
+        case let .currentValue(key: key, value: value, resolvedBy: source):
+            return "Current value of flag '\(key)' is '\(String(describing: value))'. Resolved by: \(source ?? "Default value")"
+        case let .changedValue(key: key, value: value, resolvedBy: source, changedBy: trigger):
+            return "Value of flag '\(key)' was changed to '\(String(describing: value))' by '\(trigger ?? "an unknown source")'. Resolved by: \(source ?? "Default value")"
+        }
+    }
+
+}
+
+
+// MARK: - Errors
+
+public extension FlagPoleDiagnostic {
+
+    enum Error: LocalizedError {
+        case notEnabledForSnapshot
+
+        public var errorDescription: String? {
+            switch self {
+            case .notEnabledForSnapshot:
+                return "This snapshot was not taken with diagnostics enabled. Take it again using `FlagPole.snapshot(enableDiagnostics: true)`"
+            }
+        }
+    }
+
+}

--- a/Sources/Vexil/Flag.swift
+++ b/Sources/Vexil/Flag.swift
@@ -42,7 +42,7 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
 
     /// The `Flag` value. This is a calculated property based on the `FlagPole`s sources.
     public var wrappedValue: Value {
-        return value(in: nil) ?? self.defaultValue
+        return value(in: nil)?.value ?? self.defaultValue
     }
 
     /// The string-based Key for this `Flag`, as calculated during `init`. This key is
@@ -149,9 +149,11 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
 
     // MARK: - Lookup Support
 
-    func value (in source: FlagValueSource?) -> Value? {
-        guard let lookup = self.decorator.lookup, let key = self.decorator.key else { return self.defaultValue }
-        let value: Value? = lookup.lookup(key: key, in: source)
+    func value (in source: FlagValueSource?) -> LookupResult<Value>? {
+        guard let lookup = self.decorator.lookup, let key = self.decorator.key else {
+            return LookupResult(source: nil, value: self.defaultValue)
+        }
+        let value: LookupResult<Value>? = lookup.lookup(key: key, in: source)
 
         // if we're looking up against a specific source we return only what we get from it
         if source != nil {
@@ -159,7 +161,7 @@ public struct Flag<Value>: Decorated, Identifiable where Value: FlagValue {
         }
 
         // otherwise we're looking up on the FlagPole - which must always return a value so go back to our default
-        return value ?? self.defaultValue
+        return value ?? LookupResult(source: nil, value: self.defaultValue)
     }
 
 }

--- a/Sources/Vexil/Snapshots/AnyFlag.swift
+++ b/Sources/Vexil/Snapshots/AnyFlag.swift
@@ -8,17 +8,16 @@
 protocol AnyFlag {
     var key: String { get }
 
-    func getFlagValue (in source: FlagValueSource?) -> Any?
+    func getFlagValue (in source: FlagValueSource?, diagnosticsEnabled: Bool) -> LocatedFlagValue?
     func save (to source: FlagValueSource) throws
 }
 
-protocol AnyFlagGroup {
-    func allFlags () -> [AnyFlag]
-}
-
 extension Flag: AnyFlag {
-    func getFlagValue(in source: FlagValueSource?) -> Any? {
-        return value(in: source)
+    func getFlagValue (in source: FlagValueSource?, diagnosticsEnabled: Bool) -> LocatedFlagValue? {
+        guard let result = value(in: source) else {
+            return nil
+        }
+        return LocatedFlagValue(lookupResult: result, diagnosticsEnabled: diagnosticsEnabled)
     }
 
     func save(to source: FlagValueSource) throws {
@@ -26,6 +25,12 @@ extension Flag: AnyFlag {
     }
 }
 
+
+// MARK: - Flag Groups
+
+protocol AnyFlagGroup {
+    func allFlags () -> [AnyFlag]
+}
 
 extension FlagGroup: AnyFlagGroup {
     func allFlags () -> [AnyFlag] {

--- a/Sources/Vexil/Snapshots/LocatedFlagValue.swift
+++ b/Sources/Vexil/Snapshots/LocatedFlagValue.swift
@@ -1,0 +1,80 @@
+//
+//  LocatedFlagValue.swift
+//  Vexil
+//
+//  Created by Rob Amos on 13/12/21.
+//
+
+/// A wrapper type used in snapshots to support diagnostics
+///
+/// - Note: It does incur the penalty of keeping boxed and unboxed copies of flag values in
+/// memory. The alternative to that is the diagnostics setup needing to walk the flag
+/// hierarchy so we can get access to the generic type. This will be improved in the future.
+///
+struct LocatedFlagValue {
+
+    /// The name of the source that the value was located in.
+    /// Optional means no source included it, ie its a default value
+    let source: String?
+
+    /// The raw type-erased value
+    let value: Any
+
+    /// The boxed value. This will be nil if diagnostics was not enabled.
+    let boxed: BoxedFlagValue?
+
+
+    // MARK: - Initialisation
+
+    /// Memberwise initialisation of a LocatedFlagValue
+    ///
+    /// - Parameters:
+    ///   - source:     The name of the source that the value was located in.
+    ///   - value:      The raw type-erased value
+    ///   - boxed:      The boxed value. This will be nil if diagnostics was not enabled.
+    private init(source: String?, value: Any, boxed: BoxedFlagValue?) {
+        self.source = source
+        self.value = value
+        self.boxed = boxed
+    }
+
+    /// Initialises a new `LocatedFlagValue`` by type-erasing the provided Value
+    ///
+    /// If diagnostics are enabled the `BoxedFlagValue` will be captured alongside the type-erased value
+    ///
+    init<Value> (source: String?, value: Value, diagnosticsEnabled: Bool) where Value: FlagValue {
+        self.init(
+            source: source,
+            value: value,
+            boxed: diagnosticsEnabled ? value.boxedFlagValue : nil
+        )
+    }
+
+}
+
+
+// MARK: - LookupResult Conversion
+
+extension LocatedFlagValue {
+
+    /// Initialises a new `LocatedFlagValue`` by type-erasing the provided `LookupResult`
+    ///
+    /// If diagnostics are enabled the `BoxedFlagValue` will be captured alongside the type-erased value
+    ///
+    init<Value> (lookupResult: LookupResult<Value>, diagnosticsEnabled: Bool) where Value: FlagValue {
+        self.init(
+            source: lookupResult.source,
+            value: lookupResult.value,
+            diagnosticsEnabled: diagnosticsEnabled
+        )
+    }
+
+    /// Returns the specialised `LookupResult` for the receiving `LocatedFlagValue`
+    func toLookupResult<Value> () -> LookupResult<Value>? {
+        guard let value = self.value as? Value else {
+            return nil
+        }
+        return LookupResult(source: self.source, value: value)
+    }
+
+}

--- a/Sources/Vexil/Snapshots/Snapshot+FlagValueSource.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+FlagValueSource.swift
@@ -11,7 +11,7 @@ extension Snapshot: FlagValueSource {
     }
 
     public func flagValue<Value>(key: String) -> Value? where Value: FlagValue {
-        return self.values[key] as? Value
+        return self.values[key]?.value as? Value
     }
 
     public func setFlagValue<Value>(_ value: Value?, key: String) throws where Value: FlagValue {

--- a/Sources/Vexil/Snapshots/Snapshot+Lookup.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+Lookup.swift
@@ -10,9 +10,9 @@ import Combine
 #endif
 
 extension Snapshot: Lookup {
-    func lookup<Value>(key: String, in source: FlagValueSource?) -> Value? where Value: FlagValue {
+    func lookup<Value>(key: String, in source: FlagValueSource?) -> LookupResult<Value>? where Value: FlagValue {
         self.lastAccessedKey = key
-        return self.values[key] as? Value
+        return self.values[key]?.toLookupResult()
     }
 
     #if !os(Linux)

--- a/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
@@ -28,14 +28,19 @@ extension FlagValueDictionary: FlagValueSource {
         } else {
             self.storage.removeValue(forKey: key)
         }
+
+#if !os(Linux)
+        self.valueDidChange.send([ key ])
+#endif
+
     }
 
-    #if !os(Linux)
+#if !os(Linux)
 
     public func valuesDidChange(keys: Set<String>) -> AnyPublisher<Set<String>, Never>? {
         self.valueDidChange
             .eraseToAnyPublisher()
     }
 
-    #endif
+#endif
 }

--- a/Sources/Vexil/Utilities/CollectionDifference.Change+Element.swift
+++ b/Sources/Vexil/Utilities/CollectionDifference.Change+Element.swift
@@ -1,0 +1,18 @@
+//
+//  CollectionDifference.Change+Element.swift
+//  Vexil
+//
+//  Created by Rob Amos on 13/12/21.
+//
+
+extension CollectionDifference.Change {
+
+    var element: ChangeElement {
+        switch self {
+        case .insert(offset: _, element: let element, associatedWith: _):           return element
+        case .remove(offset: _, element: let element, associatedWith: _):           return element
+        }
+    }
+
+}
+

--- a/Sources/Vexil/Utilities/CollectionDifference.Change+Element.swift
+++ b/Sources/Vexil/Utilities/CollectionDifference.Change+Element.swift
@@ -15,4 +15,3 @@ extension CollectionDifference.Change {
     }
 
 }
-

--- a/Sources/Vexil/Value.swift
+++ b/Sources/Vexil/Value.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 25/5/20.
 //
 
-// swiftlint:disable extension_access_modifier file_length
+// swiftlint:disable extension_access_modifier
 
 import Foundation
 

--- a/Sources/Vexil/Vexil.docc/Diagnostics.md
+++ b/Sources/Vexil/Vexil.docc/Diagnostics.md
@@ -1,0 +1,61 @@
+# Diagnostics
+
+Debug issues with flag resolutions and real-time updates using diagnostics.
+
+## Overview
+
+A Vexil ``FlagPole`` is flexible. But that flexibility can quickly grow into complexity if it isn't managed properly. Say you have a remote flag provider like Launch Darkly or Firebase Remote Config, as well as allowing your testers to override flag values via `UserDefaults`, and maybe you like to have some pre-defined flags for each of your non-production environments. How do you know what your flag values are at any one time and why? Especially when your app is running on a user's device.
+
+## Point-in-time diagnostics
+
+Vexil provides diagnostics in two places. The first allows you to inspect the current ``FlagPole`` to see how it is currently resolving flag values.
+
+```swift
+let diagnostics = flagPole.makeDiagnostics()
+print(diagnostics)
+
+// Prints:
+// Current value of flag 'flag1' is 'bool(false)'. Resolved by: Default value
+// Current value of flag 'flag2' is 'bool(true)'. Resolved by: UserDefaults.standard
+```
+
+You can view them on a ``Snapshot`` too, if that snapshot was taken with diagnostics enabled.
+
+```swift
+let snapshot1 = flagPole.snapshot()
+let diagnostics1 = try snapshot1.makeDiagnostics() // This snapshot was not taken with diagnostics enabled. 
+
+let snapshot2 = flagPole.snapshot(enableDiagnostics: true)
+let diagnostics2 = try snapshot2.makeDiagnostics()
+```
+
+## Real-time diagnostics
+
+Vexil also supports capturing real-time diagnostics alongside the real-time flag publishing. Every time a flag value is changed somewhere in your flag hierarchy, a diagnostic will be emitted that tells you which flag source initiated the change, and how the flag is resolving.
+
+```swift
+let diagnosticsPublisher = flagPole.makeDiagnosticsPublisher()
+
+diagnosticsPublisher.sink { diagnostic in
+	print(diagnostic)
+}
+
+// prints
+// Current value of flag 'flag1' is 'bool(false)'. Resolved by: Default value
+// Current value of flag 'flag2' is 'bool(false)'. Resolved by: Default value
+// Value of flag `flag2` was changed to `bool(true)` by UserDefaults.standard. Resolved by: UserDefaults.standard
+
+```
+
+## Performance impact
+
+Diagnostics aren't free – we keep an additional boxed copy of each ``FlagValue`` in memory in addition to its raw value. This is so that when we hand you the diagnostics you can make sense of them without needing to undo the type-erasure, which requires access to the Generic information stored in your flag hierarchy.
+
+## Topics
+
+### Diagnostics
+
+- ``FlagPoleDiagnostic``
+- ``FlagPole/makeDiagnostics()``
+- ``FlagPole/makeDiagnosticsPublisher()``
+- ``Snapshot/makeDiagnostics()``

--- a/Sources/Vexil/Vexil.docc/FlagKeys.md
+++ b/Sources/Vexil/Vexil.docc/FlagKeys.md
@@ -124,7 +124,7 @@ Similarly to the ``Flag``s, we can customise the calculation of the ``FlagGroup`
 
 ### Skipping FlagGroups
 
-It does support an additional ``CodingKeyStrategy`` though: `.skip`. Which will ignore that ``FlagGroup``s key in the calculation:
+It does support an additional ``FlagGroup/CodingKeyStrategy`` though: `.skip`. Which will ignore that ``FlagGroup``s key in the calculation:
 
 ```swift
 struct MyFlags: FlagContainer {

--- a/Sources/Vexil/Vexil.docc/Sources.md
+++ b/Sources/Vexil/Vexil.docc/Sources.md
@@ -65,7 +65,7 @@ flagPole.save(snapshot: snapshot, to: UserDefaults.standard)
 
 ## Custom sources
 
-To implement your own source you need only conform to the ``FlagPoleSource`` protocol and implement its two key methods:
+To implement your own source you need only conform to the ``FlagValueSource`` protocol and implement its two key methods:
 
 ```swift
 public protocol FlagValueSource {

--- a/Sources/Vexil/Vexil.docc/Vexil.md
+++ b/Sources/Vexil/Vexil.docc/Vexil.md
@@ -164,4 +164,9 @@ Vexil includes support for a number of sources out of the box, including `UserDe
 - ``FlagDisplayValue``
 - ``FlagInfo``
 
+### Diagnostics
+
+- <doc:Diagnostics>
+- ``FlagPoleDiagnostic``
+
 [swift-argument-parser]: https://github.com/apple/swift-argument-parser

--- a/Tests/VexilTests/DiagnosticsTests.swift
+++ b/Tests/VexilTests/DiagnosticsTests.swift
@@ -1,0 +1,132 @@
+//
+//  DiagnosticsTests.swift
+//  Vexil
+//
+//  Created by Rob Amos on 12/12/21.
+//
+
+#if canImport(Combine)
+
+import Combine
+import Vexil
+import XCTest
+
+final class DiagnosticsTests: XCTestCase {
+
+    func testEmitsExpectedDiagnostics() throws {
+
+        // GIVEN a FlagPole with three different FlagSources
+        let source1 = FlagValueDictionary([
+            "top-level-flag": .bool(true)
+        ])
+        let source2 = FlagValueDictionary([
+            "subgroup.second-level-flag": .bool(true)
+        ])
+        let source3 = FlagValueDictionary([
+            "top-level-flag": .bool(true),
+            "second-test-flag": .bool(true),
+            "subgroup.second-level-flag": .bool(true)
+        ])
+        let pole = FlagPole(hoist: TestFlags.self, sources: [ source1, source2 ])
+
+        var receivedDiagnostics: [[FlagPoleDiagnostic]] = []
+        let expectation = self.expectation(description: "received diagnostics")
+        expectation.expectedFulfillmentCount = 5
+        expectation.assertForOverFulfill = true
+
+        // WHEN we subscribe to diagnostics and then make a bunch of changes
+        let cancellable = pole.makeDiagnosticsPublisher()
+            .sink {
+                receivedDiagnostics.append($0)
+                expectation.fulfill()
+            }
+
+        // 1. Change a value in the top source that is still a default
+        source1["second-test-flag"] = .bool(true)
+
+        // 2. Change a value in the source source that will be overridden by the first source regardless
+        source2["top-level-flag"] = .bool(false)
+
+        // 3. Insert a new source into the hierarchy between the two sources
+        pole._sources.insert(source3, at: 1)
+
+        // 4. Remove that source again
+        pole._sources.removeAll(where: { $0.name == source3.name })
+
+        // THEN everything should line up with the above changes
+        self.wait(for: [ expectation ], timeout: 1.0)
+        XCTAssertEqual(receivedDiagnostics.count, 5)
+
+        // 0. We should have gotten the default value of all flags
+        let initial = receivedDiagnostics[safe: 0]
+        XCTAssertEqual(initial?.count, 4)
+        XCTAssertEqual(initial?[safe: 0], .currentValue(key: "second-test-flag", value: .bool(false), resolvedBy: nil))
+        XCTAssertEqual(initial?[safe: 1], .currentValue(key: "subgroup.double-subgroup.third-level-flag", value: .bool(false), resolvedBy: nil))
+        XCTAssertEqual(initial?[safe: 2], .currentValue(key: "subgroup.second-level-flag", value: .bool(true), resolvedBy: source2.name))
+        XCTAssertEqual(initial?[safe: 3], .currentValue(key: "top-level-flag", value: .bool(true), resolvedBy: source1.name))
+
+        // 1. Changed value in the top source, it should be resolved by that source
+        let first = receivedDiagnostics[safe: 1]
+        XCTAssertEqual(first?.count, 1)
+        XCTAssertEqual(first?[safe: 0], .changedValue(key: "second-test-flag", value: .bool(true), resolvedBy: source1.name, changedBy: source1.name))
+
+        // 2. Changed value in the second source, but there is also a value set in the top source
+        let second = receivedDiagnostics[safe: 2]
+        XCTAssertEqual(second?.count, 1)
+        XCTAssertEqual(second?[safe: 0], .changedValue(key: "top-level-flag", value: .bool(true), resolvedBy: source1.name, changedBy: source2.name))
+
+        // 3. Inserted new source into the hierarchy, with one overridden, one overriding, and one unique value
+        let third = receivedDiagnostics[safe: 3]
+        XCTAssertEqual(third?.count, 4)
+        XCTAssertEqual(third?[safe: 0], .changedValue(key: "second-test-flag", value: .bool(true), resolvedBy: source1.name, changedBy: source3.name))
+        XCTAssertEqual(third?[safe: 1], .changedValue(key: "subgroup.double-subgroup.third-level-flag", value: .bool(false), resolvedBy: nil, changedBy: source3.name))
+        XCTAssertEqual(third?[safe: 2], .changedValue(key: "subgroup.second-level-flag", value: .bool(true), resolvedBy: source3.name, changedBy: source3.name))
+        XCTAssertEqual(third?[safe: 3], .changedValue(key: "top-level-flag", value: .bool(true), resolvedBy: source1.name, changedBy: source3.name))
+
+        // 3. Inserted that source again, values should reflect previous state with source3 as the changedBy
+        let fourth = receivedDiagnostics[safe: 4]
+        XCTAssertEqual(fourth?.count, 4)
+        XCTAssertEqual(fourth?[safe: 0], .changedValue(key: "second-test-flag", value: .bool(true), resolvedBy: source1.name, changedBy: source3.name))
+        XCTAssertEqual(fourth?[safe: 1], .changedValue(key: "subgroup.double-subgroup.third-level-flag", value: .bool(false), resolvedBy: nil, changedBy: source3.name))
+        XCTAssertEqual(fourth?[safe: 2], .changedValue(key: "subgroup.second-level-flag", value: .bool(true), resolvedBy: source2.name, changedBy: source3.name))
+        XCTAssertEqual(fourth?[safe: 3], .changedValue(key: "top-level-flag", value: .bool(true), resolvedBy: source1.name, changedBy: source3.name))
+
+        XCTAssertNotNil(cancellable)
+    }
+
+}
+
+
+// MARK: - Fixtures
+
+private struct TestFlags: FlagContainer {
+
+    @Flag(default: false, description: "Top level test flag")
+    var topLevelFlag: Bool
+
+    @Flag(default: false, description: "Second test flag")
+    var secondTestFlag: Bool
+
+    @FlagGroup(description: "Subgroup of test flags")
+    var subgroup: SubgroupFlags
+
+}
+
+private struct SubgroupFlags: FlagContainer {
+
+    @Flag(default: false, description: "Second level test flag")
+    var secondLevelFlag: Bool
+
+    @FlagGroup(description: "Another level of test flags")
+    var doubleSubgroup: DoubleSubgroupFlags
+
+}
+
+private struct DoubleSubgroupFlags: FlagContainer {
+
+    @Flag(default: false, description: "Third level test flag")
+    var thirdLevelFlag: Bool
+
+}
+
+#endif // canImport(Combine)

--- a/Tests/VexilTests/DiagnosticsTests.swift
+++ b/Tests/VexilTests/DiagnosticsTests.swift
@@ -5,6 +5,8 @@
 //  Created by Rob Amos on 12/12/21.
 //
 
+// swiftlint:disable let_var_whitespace function_body_length
+
 #if canImport(Combine)
 
 import Combine

--- a/Tests/VexilTests/DiagnosticsTests.swift
+++ b/Tests/VexilTests/DiagnosticsTests.swift
@@ -5,7 +5,7 @@
 //  Created by Rob Amos on 12/12/21.
 //
 
-// swiftlint:disable let_var_whitespace function_body_length
+// swiftlint:disable function_body_length
 
 #if canImport(Combine)
 

--- a/Tests/VexilTests/EquatableTests.swift
+++ b/Tests/VexilTests/EquatableTests.swift
@@ -5,8 +5,6 @@
 //  Created by Rob Amos on 18/3/21.
 //
 
-// swiftlint:disable let_var_whitespace
-
 @testable import Vexil
 import XCTest
 

--- a/Tests/VexilTests/FlagValueCompilationTests.swift
+++ b/Tests/VexilTests/FlagValueCompilationTests.swift
@@ -201,7 +201,7 @@ final class FlagValueCompilationTests: XCTestCase {
 
 }
 
-// swiftlint:disable let_var_whitespace unavailable_function
+// swiftlint:disable unavailable_function
 
 // MARK: - Generic Flag Time
 

--- a/Tests/VexilTests/FlagValueDictionaryTests.swift
+++ b/Tests/VexilTests/FlagValueDictionaryTests.swift
@@ -135,7 +135,6 @@ final class FlagValueDictionaryTests: XCTestCase {
 
 // MARK: - Fixtures
 
-// swiftlint:disable let_var_whitespace
 
 private struct TestFlags: FlagContainer {
 

--- a/Tests/VexilTests/FlagValueSourceTests.swift
+++ b/Tests/VexilTests/FlagValueSourceTests.swift
@@ -95,7 +95,6 @@ final class FlagValueSourceTests: XCTestCase {
 
 // MARK: - Fixtures
 
-// swiftlint:disable let_var_whitespace
 
 private struct TestFlags: FlagContainer {
 

--- a/Tests/VexilTests/KeyEncodingTests.swift
+++ b/Tests/VexilTests/KeyEncodingTests.swift
@@ -5,7 +5,6 @@
 //  Created by Rob Amos on 10/7/20.
 //
 
-// swiftlint:disable let_var_whitespace
 
 import Vexil
 import XCTest

--- a/Tests/VexilTests/PublisherTests.swift
+++ b/Tests/VexilTests/PublisherTests.swift
@@ -203,7 +203,6 @@ final class PublisherTests: XCTestCase {
 
 // MARK: - Test Fixtures
 
-// swiftlint:disable let_var_whitespace
 
 private struct TestFlags: FlagContainer {
 

--- a/Tests/VexilTests/SnapshotTests.swift
+++ b/Tests/VexilTests/SnapshotTests.swift
@@ -5,7 +5,6 @@
 //  Created by Rob Amos on 16/7/20.
 //
 
-// swiftlint:disable let_var_whitespace
 
 import Vexil
 import XCTest


### PR DESCRIPTION
### 📒 Description

Added basic diagnostics for:

- Point-in-time flag resolution using `flagPole.makeDiagnostics()` and `try snapshot.makeDiagnostics()`
- Real-time flag updates using `flagPole.makeDiagnosticsPublisher()`

See [Diagnostics.md](https://github.com/unsignedapps/Vexil/blob/51799314613d7e124fb0f53d52155d9da930e55b/Sources/Vexil/Vexil.docc/Diagnostics.md) for more info and usage.