### PR TITLE
Added a read-only view to Vexillographer

### DIFF
--- a/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/BooleanFlagControl.swift
@@ -28,6 +28,7 @@ struct BooleanFlagControl: View {
     @Binding var value: Bool
 
     let hasChanges: Bool
+    let isEditable: Bool
     @Binding var showDetail: Bool
 
 
@@ -35,7 +36,13 @@ struct BooleanFlagControl: View {
 
     var body: some View {
         HStack {
-            Toggle(self.label, isOn: self.$value)
+            if self.isEditable {
+                Toggle(self.label, isOn: self.$value)
+            } else {
+                Text(self.label).font(.headline)
+                Spacer()
+                FlagDisplayValueView(value: self.value)
+            }
             DetailButton(hasChanges: self.hasChanges, showDetail: self.$showDetail)
         }
     }
@@ -63,6 +70,7 @@ extension UnfurledFlag: BooleanEditableFlag where Value.BoxedValueType == Bool {
                 transformer: BoxedPassthroughTransformer.self
             ),
             hasChanges: manager.hasValueInSource(flag: self.flag),
+            isEditable: manager.isEditable,
             showDetail: showDetail
         )
             .eraseToAnyView()
@@ -90,6 +98,7 @@ extension UnfurledFlag: OptionalBooleanEditableFlag where Value: FlagValue, Valu
                 transformer: OptionalTransformer<Value.BoxedValueType, Bool, BoxedPassthroughTransformer>.self
             ),
             hasChanges: manager.hasValueInSource(flag: self.flag),
+            isEditable: manager.isEditable,
             showDetail: showDetail
         )
             .eraseToAnyView()

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -60,11 +60,13 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
 
     #elseif os(macOS)
 
-    @ViewBuilder var body: some View {
-        if self.isEditable {
-            self.picker
-        } else {
-            self.content
+    var body: some View {
+        Group {
+            if self.isEditable {
+                self.picker
+            } else {
+                self.content
+            }
         }
     }
 

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -23,22 +23,31 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
     @Binding var value: Value
 
     let hasChanges: Bool
+    let isEditable: Bool
     @Binding var showDetail: Bool
 
     @Binding var showPicker: Bool
 
     // MARK: - View Body
 
+    var content: some View {
+        HStack {
+            Text(self.label).font(.headline)
+            Spacer()
+            FlagDisplayValueView(value: self.value)
+        }
+    }
+
     #if os(iOS)
 
     var body: some View {
         HStack {
-            NavigationLink(destination: self.selector, isActive: self.$showPicker) {
-                HStack {
-                    Text(self.label).font(.headline)
-                    Spacer()
-                    FlagDisplayValueView(value: self.value)
+            if self.isEditable {
+                NavigationLink(destination: self.selector, isActive: self.$showPicker) {
+                    self.content
                 }
+            } else {
+                self.content
             }
             DetailButton(hasChanges: self.hasChanges, showDetail: self.$showDetail)
         }
@@ -51,7 +60,15 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
 
     #elseif os(macOS)
 
-    var body: some View {
+    @ViewBuilder var body: some View {
+        if self.isEditable {
+            self.picker
+        } else {
+            self.content
+        }
+    }
+
+    var picker: some View {
         let picker = Picker (
             selection: self.$value,
             label: Text(self.label),
@@ -138,6 +155,7 @@ extension UnfurledFlag: CaseIterableEditableFlag
                 transformer: PassthroughTransformer<Value>.self
             ),
             hasChanges: manager.hasValueInSource(flag: self.flag),
+            isEditable: manager.isEditable,
             showDetail: showDetail,
             showPicker: showPicker
         )

--- a/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
@@ -25,20 +25,29 @@ struct OptionalCaseIterableFlagControl<Value>: View
     @Binding var value: Value
 
     let hasChanges: Bool
+    let isEditable: Bool
     @Binding var showDetail: Bool
 
     @Binding var showPicker: Bool
 
     // MARK: - View Body
 
+    var content: some View {
+        HStack {
+            Text(self.label).font(.headline)
+            Spacer()
+            FlagDisplayValueView(value: self.value.wrapped)
+        }
+    }
+
     var body: some View {
         HStack {
-            NavigationLink(destination: self.selector, isActive: self.$showPicker) {
-                HStack {
-                    Text(self.label).font(.headline)
-                    Spacer()
-                    FlagDisplayValueView(value: self.value.wrapped)
+            if self.isEditable {
+                NavigationLink(destination: self.selector, isActive: self.$showPicker) {
+                    self.content
                 }
+            } else {
+                self.content
             }
             DetailButton(hasChanges: self.hasChanges, showDetail: self.$showDetail)
         }
@@ -147,6 +156,7 @@ extension UnfurledFlag: OptionalCaseIterableEditableFlag
                 }
             ),
             hasChanges: manager.hasValueInSource(flag: self.flag),
+            isEditable: manager.isEditable,
             showDetail: showDetail,
             showPicker: showPicker
         )

--- a/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
@@ -145,7 +145,7 @@ extension UnfurledFlag: OptionalCaseIterableEditableFlag
         return OptionalCaseIterableFlagControl<Value> (
             label: label,
             value: Binding (
-                get: { Value(manager.rawValue(key: key)) },
+                get: { Value(manager.flagValue(key: key)) },
                 set: { newValue in
                     do {
                         try manager.setFlagValue(newValue.wrapped, key: key)

--- a/Sources/Vexillographer/Flag Value Controls/StringFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/StringFlagControl.swift
@@ -23,6 +23,7 @@ struct StringFlagControl: View {
     @Binding var value: String
 
     let hasChanges: Bool
+    let isEditable: Bool
     @Binding var showDetail: Bool
 
 
@@ -32,8 +33,12 @@ struct StringFlagControl: View {
         HStack {
             Text(self.label)
             Spacer()
-            TextField("", text: self.$value)
-                .multilineTextAlignment(.trailing)
+            if self.isEditable {
+                TextField("", text: self.$value)
+                    .multilineTextAlignment(.trailing)
+            } else {
+                FlagDisplayValueView(value: self.value)
+            }
             DetailButton(hasChanges: self.hasChanges, showDetail: self.$showDetail)
         }
     }
@@ -60,6 +65,7 @@ extension UnfurledFlag: StringEditableFlag where Value.BoxedValueType: LosslessS
                 transformer: LosslessStringTransformer<Value.BoxedValueType>.self
             ),
             hasChanges: manager.hasValueInSource(flag: self.flag),
+            isEditable: manager.isEditable,
             showDetail: showDetail
         )
             .flagValueKeyboard(type: Value.self)
@@ -90,6 +96,7 @@ extension UnfurledFlag: OptionalStringEditableFlag
                 transformer: OptionalTransformer<Value.BoxedValueType, String, LosslessStringTransformer<Value.BoxedValueType.WrappedFlagValue>>.self
             ),
             hasChanges: manager.hasValueInSource(flag: self.flag),
+            isEditable: manager.isEditable,
             showDetail: showDetail
         )
             .flagValueKeyboard(type: Value.self)

--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -74,13 +74,13 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
                 }
             }
 
-            if let source = self.manager.source {
+            if self.manager.source != nil {
                 FlagDetailSection(header: Text("Current Source")) {
                     HStack {
-                        Text(source.name)
+                        Text(self.manager.source!.name)
                             .font(.headline)
                         Spacer()
-                        self.description(source: source)
+                        self.description(source: self.manager.source!)
                     }
 
                     Button(action: self.clearValue) {

--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -16,6 +16,7 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
     // MARK: - Properties
 
     let flag: UnfurledFlag<Value, RootGroup>
+    let isEditable: Bool
 
     @ObservedObject var manager: FlagValueManager<RootGroup>
 
@@ -25,6 +26,7 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
     init (flag: UnfurledFlag<Value, RootGroup>, manager: FlagValueManager<RootGroup>) {
         self.flag = flag
         self.manager = manager
+        self.isEditable = manager.isEditable
     }
 
 
@@ -72,22 +74,24 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
                 }
             }
 
-            FlagDetailSection(header: Text("Current Source")) {
-                HStack {
-                    Text(self.manager.source.name)
-                        .font(.headline)
-                    Spacer()
-                    self.description(source: self.manager.source)
-                }
+            if let source = self.manager.source {
+                FlagDetailSection(header: Text("Current Source")) {
+                    HStack {
+                        Text(source.name)
+                            .font(.headline)
+                        Spacer()
+                        self.description(source: source)
+                    }
 
-                Button(action: self.clearValue) {
-                    Text("Clear Flag Value in Current Source")
+                    Button(action: self.clearValue) {
+                        Text("Clear Flag Value in Current Source")
+                    }
+                    .foregroundColor(.red)
+                    .opacity(self.isCurrentSourceSet ? 1 : 0.3)
+                    .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+                    .disabled(self.isCurrentSourceSet == false)
+                    .animation(.easeInOut, value: self.isCurrentSourceSet)
                 }
-                .foregroundColor(.red)
-                .opacity(self.isCurrentSourceSet ? 1 : 0.3)
-                .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
-                .disabled(self.isCurrentSourceSet == false)
-                .animation(.easeInOut, value: self.isCurrentSourceSet)
             }
 
             FlagDetailSection(header: Text("FlagPole Source Hierarchy")) {
@@ -125,11 +129,14 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
     }
 
     func clearValue () {
-        try? self.manager.source.setFlagValue(Optional<Value>.none, key: self.flag.flag.key)        // swiftlint:disable:this syntactic_sugar
+        try? self.manager.source?.setFlagValue(Optional<Value>.none, key: self.flag.flag.key)        // swiftlint:disable:this syntactic_sugar
     }
 
     var isCurrentSourceSet: Bool {
-        self.flagValue(source: self.manager.source) != nil
+        guard let source = self.manager.source else {
+            return false
+        }
+        return self.flagValue(source: source) != nil
     }
 
     private var flagKeyView: some View {

--- a/Sources/Vexillographer/FlagDisplayValueView.swift
+++ b/Sources/Vexillographer/FlagDisplayValueView.swift
@@ -17,41 +17,50 @@ struct FlagDisplayValueView<Value>: View where Value: FlagValue {
 
     let value: Value
 
+    var string: String? {
+        if let value = self.value as? OptionalFlagDisplayValue {
+            return value.flagDisplayValue
+        }
+        if let displayValue = value as? FlagDisplayValue {
+            return displayValue.flagDisplayValue
+        }
+        return String(describing: value)
+    }
 
     // MARK: - Body
 
     var body: some View {
-        return (self.value as? OptionalFlagDisplayValue)?.flagDisplayText
-            ?? (self.value as? FlagDisplayValue)?.flagDisplayText
-            ?? Text(String(describing: self.value)).eraseToAnyView()
+        Group {
+            if self.string != nil {
+                Text(string!)
+                    .contextMenu {
+                        CopyButton(action: self.string!.copyToPasteboard)
+                    }
+
+            } else {
+                Text("nil").foregroundColor(.red)
+            }
+        }
     }
 
 }
 
 private protocol OptionalFlagDisplayValue {
-    var flagDisplayText: AnyView { get }
+    var flagDisplayValue: String? { get }
 }
 
 extension Optional: OptionalFlagDisplayValue where Wrapped: FlagValue {
-    var flagDisplayText: AnyView {
+    var flagDisplayValue: String? {
         guard let value = self else {
-            return Text("nil")
-                .foregroundColor(.red)
-                .eraseToAnyView()
+            return nil
         }
 
-        let string = (value as? FlagDisplayValue)?.flagDisplayValue ?? String(describing: value)
-        return Text(string)
-            .eraseToAnyView()
+        if let displayValue = value as? FlagDisplayValue {
+            return displayValue.flagDisplayValue
+        }
+
+        return String(describing: value)
     }
 }
-
-private extension FlagDisplayValue {
-    var flagDisplayText: AnyView {
-        return Text(self.flagDisplayValue)
-            .eraseToAnyView()
-    }
-}
-
 
 #endif

--- a/Sources/Vexillographer/FlagValueManager.swift
+++ b/Sources/Vexillographer/FlagValueManager.swift
@@ -18,13 +18,17 @@ class FlagValueManager<RootGroup>: ObservableObject where RootGroup: FlagContain
     // MARK: - Properties
 
     let flagPole: FlagPole<RootGroup>
-    let source: FlagValueSource
+    let source: FlagValueSource?
     private var cancellables = Set<AnyCancellable>()
+
+    var isEditable: Bool {
+        return self.source != nil
+    }
 
 
     // MARK: - Initialisation
 
-    init (flagPole: FlagPole<RootGroup>, source: FlagValueSource) {
+    init (flagPole: FlagPole<RootGroup>, source: FlagValueSource?) {
         self.flagPole = flagPole
         self.source = source
 
@@ -41,7 +45,7 @@ class FlagValueManager<RootGroup>: ObservableObject where RootGroup: FlagContain
     // MARK: - Flag Values
 
     func rawValue<Value> (key: String) -> Value? where Value: FlagValue {
-        return self.source.flagValue(key: key)
+        return self.source?.flagValue(key: key)
     }
 
     func flagValue<Value> (key: String) -> Value? where Value: FlagValue {
@@ -50,13 +54,17 @@ class FlagValueManager<RootGroup>: ObservableObject where RootGroup: FlagContain
     }
 
     func setFlagValue<Value> (_ value: Value?, key: String) throws where Value: FlagValue {
+        guard let source = source else {
+            return
+        }
+
         let snapshot = self.flagPole.emptySnapshot()
         try snapshot.setFlagValue(value, key: key)
-        try self.flagPole.save(snapshot: snapshot, to: self.source)
+        try self.flagPole.save(snapshot: snapshot, to: source)
     }
 
     func hasValueInSource<Value> (flag: Flag<Value>) -> Bool {
-        if let _: Value = self.source.flagValue(key: flag.key) {
+        if let _: Value = self.source?.flagValue(key: flag.key) {
             return true
 
         } else {

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -22,7 +22,13 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
 
     // MARK: - Initialisation
 
-    public init (flagPole: FlagPole<RootGroup>, source: FlagValueSource) {
+    /// Initialises a new `Vexillographer` instance with the provided FlagPole and source
+    ///
+    /// - Parameters;
+    ///   - flagPole:           A `FlagPole` instance manages the flag and source hierarchy we want to display
+    ///   - source:             An optional `FlagValueSource` for editing the flag values in. If `nil` the flag values are displayed read-only
+    ///
+    public init (flagPole: FlagPole<RootGroup>, source: FlagValueSource?) {
         self.manager = FlagValueManager(flagPole: flagPole, source: source)
     }
 


### PR DESCRIPTION
### 📒 Description

The `source` parameter to the Vexillographer initialiser is now optional. If a source is passed Vexillographer can be used to edit values in that source. If the source is `nil` Vexillographer will present a read-only view of the flag hierarchy.