### PR TITLE
Reduce code bloat from `FlagContainer`s

### DIFF
--- a/Sources/Vexil/Decorator.swift
+++ b/Sources/Vexil/Decorator.swift
@@ -15,17 +15,6 @@ internal protocol Decorated {
     func decorate (lookup: Lookup, label: String, codingPath: [String], config: VexilConfiguration)
 }
 
-/// An internal class that `Flag` and `FlagGroup`s store their information in.
-/// It is specifically a class so that  the `Flag` and `FlagGroup` structs can
-/// mutate the `Decorator` while remaining immutable themselves.
-///
-internal class Decorator {
-    var key: String?
-    weak var lookup: Lookup?
-
-    init() {}
-}
-
 internal extension Sequence where Element == Mirror.Child {
 
     typealias DecoratedChild = (label: String, value: Decorated)


### PR DESCRIPTION
### 📒 Description

A few hundred flags in some nested groups could easily generate a few MB of code for their init/deinit/copy functions. By reducing the stored properties in Flag/FlagGroup to a minimum, we can reduce this bloat to a minimum. By inlining `Decorator`, the number of heap allocations can remain constant.

### 🔍 Detailed Design

Entirely API-compatible change (though IMO it could be improved by making some more Flag/FlagGroup properties read-only, and avoiding the need for `isKnownUniquelyReferenced`)

### 📓 Documentation Plan

Entirely API-compatible change

### 🗳 Test Plan

Entirely API-compatible change. Existing tests pass.

### 🧯 Source Impact

None

### ✅ Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
> (doesn't seem necessary)
- [x] I've followed the code style of the rest of the project
> (I hope 🤦‍♀️ )
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
> (doesn't seem necessary)