### PR TITLE
Protect against overflows in BoxedFlagValues

### DIFF
--- a/Sources/Vexil/Value.swift
+++ b/Sources/Vexil/Value.swift
@@ -208,8 +208,8 @@ extension Int8: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
-        self = Int8(value)
+        guard let value = Int(boxedFlagValue: boxedFlagValue).flatMap(Int8.init(exactly:)) else { return nil }
+        self = value
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -221,8 +221,8 @@ extension Int16: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
-        self = Int16(value)
+        guard let value = Int(boxedFlagValue: boxedFlagValue).flatMap(Int16.init(exactly:)) else { return nil }
+        self = value
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -234,8 +234,8 @@ extension Int32: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
-        self = Int32(value)
+        guard let value = Int(boxedFlagValue: boxedFlagValue).flatMap(Int32.init(exactly:)) else { return nil }
+        self = value
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -247,8 +247,8 @@ extension Int64: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
-        self = Int64(value)
+        guard let value = Int(boxedFlagValue: boxedFlagValue).flatMap(Int64.init(exactly:)) else { return nil }
+        self = value
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -260,8 +260,8 @@ extension UInt: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
-        self = UInt(value)
+        guard let value = Int(boxedFlagValue: boxedFlagValue).flatMap(UInt.init(exactly:)) else { return nil }
+        self = value
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -273,8 +273,8 @@ extension UInt8: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
-        self = UInt8(value)
+        guard let value = Int(boxedFlagValue: boxedFlagValue).flatMap(UInt8.init(exactly:)) else { return nil }
+        self = value
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -286,8 +286,8 @@ extension UInt16: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
-        self = UInt16(value)
+        guard let value = Int(boxedFlagValue: boxedFlagValue).flatMap(UInt16.init(exactly:)) else { return nil }
+        self = value
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -299,8 +299,8 @@ extension UInt32: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
-        self = UInt32(value)
+        guard let value = Int(boxedFlagValue: boxedFlagValue).flatMap(UInt32.init(exactly:)) else { return nil }
+        self = value
     }
 
     public var boxedFlagValue: BoxedFlagValue {
@@ -312,8 +312,8 @@ extension UInt64: FlagValue {
     public typealias BoxedValueType = Int
 
     public init? (boxedFlagValue: BoxedFlagValue) {
-        guard let value = Int(boxedFlagValue: boxedFlagValue) else { return nil }
-        self = UInt64(value)
+        guard let value = Int(boxedFlagValue: boxedFlagValue).flatMap(UInt64.init(exactly:)) else { return nil }
+        self = value
     }
 
     public var boxedFlagValue: BoxedFlagValue {

--- a/Tests/VexilTests/FlagValueUnboxingTests.swift
+++ b/Tests/VexilTests/FlagValueUnboxingTests.swift
@@ -161,6 +161,45 @@ final class FlagValueUnboxingTests: XCTestCase {
     }
 
 
+    // MARK: - Integer overflows
+
+    func testInt8FlagValueWithOverflow () {
+        let boxed = BoxedFlagValue.integer(Int(Int8.max)+1)
+
+        XCTAssertNil(Int8(boxedFlagValue: boxed))
+    }
+
+    func testInt16FlagValueWithOverflow () {
+        let boxed = BoxedFlagValue.integer(Int(Int16.max)+1)
+
+        XCTAssertNil(Int16(boxedFlagValue: boxed))
+    }
+
+    func testInt32FlagValueWithOverflow () {
+        let boxed = BoxedFlagValue.integer(Int(Int32.max)+1)
+
+        XCTAssertNil(Int32(boxedFlagValue: boxed))
+    }
+
+    func testUInt8FlagValueWithOverflow () {
+        let boxed = BoxedFlagValue.integer(Int(UInt8.max)+1)
+
+        XCTAssertNil(UInt8(boxedFlagValue: boxed))
+    }
+
+    func testUInt16FlagValueWithOverflow () {
+        let boxed = BoxedFlagValue.integer(Int(UInt16.max)+1)
+
+        XCTAssertNil(UInt16(boxedFlagValue: boxed))
+    }
+
+    func testUInt32FlagValueWithOverflow () {
+        let boxed = BoxedFlagValue.integer(Int(UInt32.max)+1)
+
+        XCTAssertNil(UInt32(boxedFlagValue: boxed))
+    }
+
+
     // MARK: - Floating Point Flag Values
 
     func testFloatFlagValue () {


### PR DESCRIPTION
### 📒 Description

Previously, attempting to unwrap an Int from a BoxedFlagValue into an FlagValue that was not wide enough would cause a runtime error.

Now, we unwrap the Int from the BoxedFlagValue and convert it into the Int type’s fallible initialiser. That way, we know it will not be too big when we do the assignment.

### 🗳 Test Plan

* Unit tests included for all Int types (except Int64, which is a little harder)

### ✅ Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

### 😠 Not finished

It's not finished. Somehow, there's double-optionals are making it into the UserDefaults FlagValueSource's set value function.

```swift
    /// Sets the value for the specified key
    public func setFlagValue<Value>(_ value: Value?, key: String) throws where Value: FlagValue {
        guard let value = value else { // unwraps a UInt16?? to UInt16?
            self.removeObject(forKey: key)
            return
        }

        self.set(value.boxedFlagValue.object, forKey: key) // tries to send nil `UInt16?` in here, which fails.
    }
```

I shall ponder because I'm not sure why they're double-optionalised now.
