### PR TITLE
Fix navigation issue for nested flags in Vexillographer

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -75,7 +75,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build and Test
-        run: swift package generate-xcodeproj && xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,name=iPhone 8"
+        run: |
+          DEVICE_ID=`xcrun simctl list --json devices available iPhone | jq -r '.devices | to_entries | map(select(.value | add)) | sort_by(.key) | last.value | first.udid'`
+          swift package generate-xcodeproj
+          xcrun xcodebuild test -scheme "Vexil-Package" -destination "platform=iOS Simulator,id=$DEVICE_ID"
 
   build-ios-macos-12:
     runs-on: ubuntu-latest

--- a/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
@@ -46,7 +46,11 @@ extension UserDefaults: FlagValueSource {
             return
         }
 
-        set(value.boxedFlagValue.object, forKey: key)
+        if value.boxedFlagValue.object == NSNull() {
+            set(Data(), forKey: key)
+        } else {
+            set(value.boxedFlagValue.object, forKey: key)
+        }
 
     }
 

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -102,9 +102,11 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
 #endif
 
     struct SelectorList: View {
-        @Binding var value: Value
+        @Binding
+        var value: Value
 
-        @Environment(\.presentationMode) private var presentationMode
+        @Environment(\.presentationMode)
+        private var presentationMode
 
         var body: some View {
             Form {

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -34,9 +34,6 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
     @Binding
     var showDetail: Bool
 
-    @Binding
-    var showPicker: Bool
-
     // MARK: - View Body
 
     var content: some View {
@@ -52,7 +49,7 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
     var body: some View {
         HStack {
             if self.isEditable {
-                NavigationLink(destination: self.selector, isActive: self.$showPicker) {
+                NavigationLink(destination: self.selector) {
                     self.content
                 }
             } else {
@@ -63,7 +60,7 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
     }
 
     var selector: some View {
-        return self.selectorList
+        SelectorList(value: self.$value)
             .navigationBarTitle(Text(self.label), displayMode: .inline)
     }
 
@@ -104,52 +101,56 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
 
 #endif
 
-    var selectorList: some View {
-        Form {
-            ForEach(Value.allCases, id: \.self) { value in
-                Button(
-                    action: {
-                        self.value = value
-                        self.showPicker = false
-                    },
-                    label: {
-                        HStack {
-                            FlagDisplayValueView(value: value)
-                                .foregroundColor(.primary)
-                            Spacer()
+    struct SelectorList: View {
+        @Binding var value: Value
 
-                            if value == self.value {
-                                self.checkmark
+        @Environment(\.presentationMode) private var presentationMode
+
+        var body: some View {
+            Form {
+                ForEach(Value.allCases, id: \.self) { value in
+                    Button(
+                        action: {
+                            self.value = value
+                            presentationMode.wrappedValue.dismiss()
+                        },
+                        label: {
+                            HStack {
+                                FlagDisplayValueView(value: value)
+                                    .foregroundColor(.primary)
+                                Spacer()
+
+                                if value == self.value {
+                                    self.checkmark
+                                }
                             }
                         }
-                    }
-                )
+                    )
+                }
             }
         }
-    }
 
 #if os(macOS)
 
-    var checkmark: some View {
-        return Text("✓")
-    }
+        var checkmark: some View {
+            return Text("✓")
+        }
 
 #else
 
-    var checkmark: some View {
-        return Image(systemName: "checkmark")
-    }
+        var checkmark: some View {
+            return Image(systemName: "checkmark")
+        }
 
 #endif
-
+    }
 }
-
 
 // MARK: - Creating CaseIterableFlagControls
 
 @available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
 protocol CaseIterableEditableFlag {
-    func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>, showPicker: Binding<Bool>) -> AnyView where RootGroup: FlagContainer
+    func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer
 }
 
 @available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
@@ -157,7 +158,7 @@ extension UnfurledFlag: CaseIterableEditableFlag
     where Value: FlagValue, Value: CaseIterable, Value.AllCases: RandomAccessCollection,
     Value: RawRepresentable, Value.RawValue: FlagValue, Value: Hashable
 {
-    func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>, showPicker: Binding<Bool>) -> AnyView where RootGroup: FlagContainer {
+    func control<RootGroup>(label: String, manager: FlagValueManager<RootGroup>, showDetail: Binding<Bool>) -> AnyView where RootGroup: FlagContainer {
         return CaseIterableFlagControl<Value>(
             label: label,
             value: Binding(
@@ -168,8 +169,7 @@ extension UnfurledFlag: CaseIterableEditableFlag
             ),
             hasChanges: manager.hasValueInSource(flag: flag),
             isEditable: manager.isEditable,
-            showDetail: showDetail,
-            showPicker: showPicker
+            showDetail: showDetail
         )
         .eraseToAnyView()
     }

--- a/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/CaseIterableFlagControl.swift
@@ -112,7 +112,7 @@ struct CaseIterableFlagControl<Value>: View where Value: FlagValue, Value: CaseI
                     Button(
                         action: {
                             self.value = value
-                            presentationMode.wrappedValue.dismiss()
+                            self.presentationMode.wrappedValue.dismiss()
                         },
                         label: {
                             HStack {

--- a/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
@@ -76,9 +76,11 @@ struct OptionalCaseIterableFlagControl<Value>: View
 #endif
 
     struct SelectorList: View {
-        @Binding var value: Value
+        @Binding
+        var value: Value
 
-        @Environment(\.presentationMode) private var presentationMode
+        @Environment(\.presentationMode)
+        private var presentationMode
 
         var body: some View {
             Form {

--- a/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
+++ b/Sources/Vexillographer/Flag Value Controls/OptionalCaseIterableFlagControl.swift
@@ -166,7 +166,7 @@ extension UnfurledFlag: OptionalCaseIterableEditableFlag
                 get: { Value(manager.flagValue(key: key)) },
                 set: { newValue in
                     do {
-                        try manager.setFlagValue(newValue.wrapped, key: key)
+                        try manager.setFlagValue(newValue, key: key)
 
                     } catch {
                         print("[Vexilographer] Could not set flag with key \"\(key)\" to \"\(newValue)\"")

--- a/Sources/Vexillographer/FlagGroupView.swift
+++ b/Sources/Vexillographer/FlagGroupView.swift
@@ -63,7 +63,7 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
                 Section {
                     // Filter out all links. They won't work on the mac flag group view.
                     ForEach(self.group.allItems().filter { $0.isLink == false }, id: \.id) { item in
-                        item.unfurledView
+                        UnfurledFlagItemView(item: item)
                     }
                 }
             }
@@ -98,7 +98,7 @@ struct UnfurledFlagGroupView<Group, Root>: View where Group: FlagContainer, Root
 
     var flags: some View {
         ForEach(self.group.allItems(), id: \.id) { item in
-            item.unfurledView
+            UnfurledFlagItemView(item: item)
         }
     }
 

--- a/Sources/Vexillographer/FlagSectionView.swift
+++ b/Sources/Vexillographer/FlagSectionView.swift
@@ -68,7 +68,7 @@ struct UnfurledFlagSectionView<Group, Root>: View where Group: FlagContainer, Ro
 
     private var content: some View {
         ForEach(self.group.allItems(), id: \.id) { item in
-            item.unfurledView
+            UnfurledFlagItemView(item: item)
         }
     }
 

--- a/Sources/Vexillographer/FlagView.swift
+++ b/Sources/Vexillographer/FlagView.swift
@@ -29,10 +29,6 @@ struct UnfurledFlagView<Value, RootGroup>: View where Value: FlagValue, RootGrou
     @State
     private var showDetail = false
 
-    @State
-    private var showPicker = false
-
-
     // MARK: - Initialisation
 
     init(flag: UnfurledFlag<Value, RootGroup>, manager: FlagValueManager<RootGroup>) {
@@ -65,10 +61,10 @@ struct UnfurledFlagView<Value, RootGroup>: View where Value: FlagValue, RootGrou
             return flag.control(label: self.flag.info.name, manager: self.manager, showDetail: self.$showDetail)
 
         } else if let flag = self.flag as? CaseIterableEditableFlag {
-            return flag.control(label: self.flag.info.name, manager: self.manager, showDetail: self.$showDetail, showPicker: self.$showPicker)
+            return flag.control(label: self.flag.info.name, manager: self.manager, showDetail: self.$showDetail)
 
         } else if let flag = self.flag as? OptionalCaseIterableEditableFlag {
-            return flag.control(label: self.flag.info.name, manager: self.manager, showDetail: self.$showDetail, showPicker: self.$showPicker)
+            return flag.control(label: self.flag.info.name, manager: self.manager, showDetail: self.$showDetail)
 
         } else if let flag = self.flag as? StringEditableFlag {
             return flag.control(label: self.flag.info.name, manager: self.manager, showDetail: self.$showDetail)

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagItem.swift
@@ -28,4 +28,13 @@ protocol UnfurledFlagItem {
     var isLink: Bool { get }
 }
 
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
+struct UnfurledFlagItemView: View {
+    var item: UnfurledFlagItem
+
+    var body: some View {
+        item.unfurledView.id(item.id)
+    }
+}
+
 #endif

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -22,10 +22,13 @@ import Vexil
 public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
 
     // MARK: - Properties
-
+#if os(macOS) && compiler(>=5.3.1)
     @ObservedObject
     var manager: FlagValueManager<RootGroup>
-
+#else
+    @State
+    var manager: FlagValueManager<RootGroup>
+#endif
 
     // MARK: - Initialisation
 

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -22,6 +22,7 @@ import Vexil
 public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
 
     // MARK: - Properties
+
 #if os(macOS) && compiler(>=5.3.1)
     @ObservedObject
     var manager: FlagValueManager<RootGroup>

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -16,6 +16,8 @@
 import SwiftUI
 import Vexil
 
+#if os(macOS) && compiler(>=5.3.1)
+
 /// A SwiftUI View that allows you to easily edit the flag
 /// structure in a provided FlagValueSource.
 @available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
@@ -23,13 +25,8 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
 
     // MARK: - Properties
 
-#if os(macOS) && compiler(>=5.3.1)
     @ObservedObject
     var manager: FlagValueManager<RootGroup>
-#else
-    @State
-    var manager: FlagValueManager<RootGroup>
-#endif
 
     // MARK: - Initialisation
 
@@ -40,13 +37,10 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
     ///   - source:             An optional `FlagValueSource` for editing the flag values in. If `nil` the flag values are displayed read-only
     ///
     public init(flagPole: FlagPole<RootGroup>, source: FlagValueSource?) {
-        self.manager = FlagValueManager(flagPole: flagPole, source: source)
+        self._manager = ObservedObject(wrappedValue: FlagValueManager(flagPole: flagPole, source: source))
     }
 
-
     // MARK: - Body
-
-#if os(macOS) && compiler(>=5.3.1)
 
     public var body: some View {
         List(self.manager.allItems(), id: \.id, children: \.childLinks) { item in
@@ -61,8 +55,31 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
             }
         }
     }
+}
 
 #else
+
+/// A SwiftUI View that allows you to easily edit the flag
+/// structure in a provided FlagValueSource.
+@available(OSX 11.0, iOS 13.0, watchOS 7.0, tvOS 13.0, *)
+public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
+
+    // MARK: - Properties
+
+    @State
+    var manager: FlagValueManager<RootGroup>
+
+    // MARK: - Initialisation
+
+    /// Initialises a new `Vexillographer` instance with the provided FlagPole and source
+    ///
+    /// - Parameters;
+    ///   - flagPole:           A `FlagPole` instance manages the flag and source hierarchy we want to display
+    ///   - source:             An optional `FlagValueSource` for editing the flag values in. If `nil` the flag values are displayed read-only
+    ///
+    public init(flagPole: FlagPole<RootGroup>, source: FlagValueSource?) {
+        self._manager = State(wrappedValue: FlagValueManager(flagPole: flagPole, source: source))
+    }
 
     public var body: some View {
         ForEach(self.manager.allItems(), id: \.id) { item in
@@ -70,8 +87,8 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
         }
         .environmentObject(self.manager)
     }
+}
 
 #endif
-}
 
 #endif

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -46,7 +46,7 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
 
     public var body: some View {
         List(self.manager.allItems(), id: \.id, children: \.childLinks) { item in
-            item.unfurledView
+            UnfurledFlagItemView(item: item)
         }
         .listStyle(SidebarListStyle())
         .toolbar {
@@ -62,7 +62,7 @@ public struct Vexillographer<RootGroup>: View where RootGroup: FlagContainer {
 
     public var body: some View {
         ForEach(self.manager.allItems(), id: \.id) { item in
-            item.unfurledView
+            UnfurledFlagItemView(item: item)
         }
         .environmentObject(self.manager)
     }


### PR DESCRIPTION
### 📒 Description

Added `UnfurledFlagItemView` to Vexillographer. Sometimes changing a deeply nested flag would cause the navigation to pop back to the root view.  `UnfurledFlagItemView` wraps `UnfurledFlagItem` so that the ID can be applied to the view stopping the navigation from popping back.

`CaseIterableFlagControl` and  `OptionalCaseIterableFlagControl` now use `@Environment(\.presentationMode)` to be dismissed instead of a binding. Introducing `UnfurledFlagItemView` changed the current behaviour and this change restores that.

`OptionalCaseIterableFlagControl` UI was slightly changed to match `CaseIterableFlagControl`


![VexillographerApp](https://github.com/unsignedapps/Vexil/assets/136431146/4ae89ed1-cb2b-4098-8d9a-6963048657c0)


### 📓 Documentation Plan

This change doesn't impact the public api. I'm not too familiar with the docs though so if there's something that this change impacts, let me know. 

### 🗳 Test Plan

None at this stage. I have a sample project for testing different flag configurations which could be made into a UI test if you'd like. I also didn't do any testing on tvOS and watchOS.

### 🧯 Source Impact

No changes to public api, however, users that relied on the current behaviour will be impacted. 

### ✅ Checklist

- [ ] ~I've added at least one test that validates that my change is working, if appropriate~
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] ~I've updated the documentation if necessary~