### PR TITLE
Tidy up `FlagValueSource`

### DIFF
--- a/Sources/Vexil/Snapshots/Snapshot+FlagValueSource.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+FlagValueSource.swift
@@ -27,4 +27,8 @@ extension Snapshot: FlagValueSource {
         set(value, key: key)
     }
 
+    public var flagValueChanges: FlagChangeStream {
+        stream.stream
+    }
+
 }

--- a/Sources/Vexil/Snapshots/Snapshot+FlagValueSource.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+FlagValueSource.swift
@@ -13,7 +13,7 @@
 
 extension Snapshot: FlagValueSource {
 
-    public var name: String {
+    public var flagValueSourceName: String {
         displayName ?? "Snapshot \(id)"
     }
 

--- a/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
@@ -37,7 +37,7 @@ extension FlagValueDictionary: FlagValueSource {
         stream.send(.some([ FlagKeyPath(key) ]))
     }
 
-    public var changes: FlagChangeStream {
+    public var flagValueChanges: FlagChangeStream {
         stream.stream
     }
 

--- a/Sources/Vexil/Sources/FlagValueDictionary.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary.swift
@@ -28,7 +28,7 @@ public final class FlagValueDictionary: Identifiable, ExpressibleByDictionaryLit
     public let id: String
 
     /// The name of our `FlagValueSource`
-    public var name: String {
+    public var flagValueSourceName: String {
         "\(String(describing: Self.self)): \(id)"
     }
 

--- a/Sources/Vexil/Sources/FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueSource.swift
@@ -30,7 +30,7 @@ public protocol FlagValueSource: AnyObject & Sendable {
     var flagValueSourceID: String { get }
 
     /// The name of the source. Used by flag editors like Vexillographer
-    var name: String { get }
+    var flagValueSourceName: String { get }
 
     /// Provide a way to fetch values. The ``BoxedFlagValue`` type is there to help with boxing and unboxing of flag values.
     func flagValue<Value>(key: String) -> Value? where Value: FlagValue

--- a/Sources/Vexil/Sources/FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueSource.swift
@@ -44,7 +44,7 @@ public protocol FlagValueSource: AnyObject & Sendable {
 
     /// Return an `AsyncSequence` that emits ``FlagChange`` values any time flag values have changed.
     /// If your implementation does not support real-time flag value monitoring you can return an ``EmptyFlagChangeStream``.
-    var changes: ChangeStream { get }
+    var flagValueChanges: ChangeStream { get }
 
 }
 

--- a/Sources/Vexil/Sources/FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueSource.swift
@@ -22,9 +22,12 @@ import Foundation
 /// For more information and examples on creating custom `FlagValueSource`s please
 /// see the full documentation.
 ///
-public protocol FlagValueSource: AnyObject & Identifiable & Sendable where ID == String {
+public protocol FlagValueSource: AnyObject & Sendable {
 
     associatedtype ChangeStream: AsyncSequence where ChangeStream.Element == FlagChange
+
+    /// A unique identifier for the flag value source. Used for identifying subscribers.
+    var flagValueSourceID: String { get }
 
     /// The name of the source. Used by flag editors like Vexillographer
     var name: String { get }
@@ -45,10 +48,8 @@ public protocol FlagValueSource: AnyObject & Identifiable & Sendable where ID ==
 
 }
 
-public extension FlagValueSource {
-
-    var id: String {
-        name
+extension FlagValueSource where Self: Identifiable, ID == String {
+    public var flagValueSourceID: String {
+        id
     }
-
 }

--- a/Sources/Vexil/Sources/FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueSource.swift
@@ -48,8 +48,8 @@ public protocol FlagValueSource: AnyObject & Sendable {
 
 }
 
-extension FlagValueSource where Self: Identifiable, ID == String {
-    public var flagValueSourceID: String {
+public extension FlagValueSource where Self: Identifiable, ID == String {
+    var flagValueSourceID: String {
         id
     }
 }

--- a/Sources/Vexil/Sources/FlagValueSourceCoordinator.swift
+++ b/Sources/Vexil/Sources/FlagValueSourceCoordinator.swift
@@ -38,6 +38,12 @@ public final class FlagValueSourceCoordinator<Source>: Sendable where Source: No
 
 extension FlagValueSourceCoordinator: FlagValueSource {
 
+    public var flagValueSourceID: String {
+        source.withLock {
+            $0.flagValueSourceID
+        }
+    }
+
     public var name: String {
         source.withLock {
             $0.name

--- a/Sources/Vexil/Sources/FlagValueSourceCoordinator.swift
+++ b/Sources/Vexil/Sources/FlagValueSourceCoordinator.swift
@@ -44,9 +44,9 @@ extension FlagValueSourceCoordinator: FlagValueSource {
         }
     }
 
-    public var name: String {
+    public var flagValueSourceName: String {
         source.withLock {
-            $0.name
+            $0.flagValueSourceName
         }
     }
 

--- a/Sources/Vexil/Sources/FlagValueSourceCoordinator.swift
+++ b/Sources/Vexil/Sources/FlagValueSourceCoordinator.swift
@@ -62,9 +62,9 @@ extension FlagValueSourceCoordinator: FlagValueSource {
         }
     }
 
-    public var changes: Source.ChangeStream {
+    public var flagValueChanges: Source.ChangeStream {
         source.withLockUnchecked {
-            $0.changes
+            $0.flagValueChanges
         }
     }
 

--- a/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
@@ -22,11 +22,11 @@ extension NSUbiquitousKeyValueStore: NonSendableFlagValueSource {
 
     /// A unique identifier for the flag value source.
     public var flagValueSourceID: String {
-        name
+        flagValueSourceName
     }
 
     /// The name of the Flag Value Source
-    public var name: String {
+    public var flagValueSourceName: String {
         "NSUbiquitousKeyValueStore\(self == NSUbiquitousKeyValueStore.default ? ".default" : "")"
     }
 

--- a/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
@@ -61,7 +61,7 @@ extension NSUbiquitousKeyValueStore: NonSendableFlagValueSource {
 
     public typealias ChangeStream = AsyncMapSequence<AsyncChain2Sequence<NotificationCenter.Notifications, NotificationCenter.Notifications>, FlagChange>
 
-    public var changes: ChangeStream {
+    public var flagValueChanges: ChangeStream {
         chain(
             NotificationCenter.default.notifications(named: Self.didChangeExternallyNotification, object: self),
             NotificationCenter.default.notifications(named: Self.didChangeInternallyNotification, object: self)

--- a/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
@@ -20,6 +20,11 @@ import Foundation
 ///
 extension NSUbiquitousKeyValueStore: NonSendableFlagValueSource {
 
+    /// A unique identifier for the flag value source.
+    public var flagValueSourceID: String {
+        name
+    }
+
     /// The name of the Flag Value Source
     public var name: String {
         "NSUbiquitousKeyValueStore\(self == NSUbiquitousKeyValueStore.default ? ".default" : "")"

--- a/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
+++ b/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
@@ -34,9 +34,12 @@ import Foundation
 /// For more information and examples on creating custom `FlagValueSource`s please
 /// see the full documentation.
 ///
-public protocol NonSendableFlagValueSource: Identifiable where ID == String {
+public protocol NonSendableFlagValueSource {
 
     associatedtype ChangeStream: AsyncSequence where ChangeStream.Element == FlagChange
+
+    /// A unique identifier for the flag value source. Used for identifying subscribers.
+    var flagValueSourceID: String { get }
 
     /// The name of the source. Used by flag editors like Vexillographer
     var name: String { get }
@@ -56,10 +59,8 @@ public protocol NonSendableFlagValueSource: Identifiable where ID == String {
 
 }
 
-public extension NonSendableFlagValueSource {
-
-    var id: String {
-        name
+extension NonSendableFlagValueSource where Self: Identifiable, ID == String {
+    public var flagValueSourceID: String {
+        id
     }
-
 }

--- a/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
+++ b/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
@@ -55,7 +55,7 @@ public protocol NonSendableFlagValueSource {
     mutating func setFlagValue(_ value: (some FlagValue)?, key: String) throws
 
     /// Return an `AsyncSequence` that emits ``FlagChange`` values any time flag values have changed.
-    var changes: ChangeStream { get }
+    var flagValueChanges: ChangeStream { get }
 
 }
 

--- a/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
+++ b/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
@@ -42,7 +42,7 @@ public protocol NonSendableFlagValueSource {
     var flagValueSourceID: String { get }
 
     /// The name of the source. Used by flag editors like Vexillographer
-    var name: String { get }
+    var flagValueSourceName: String { get }
 
     /// Provide a way to fetch values. The ``BoxedFlagValue`` type is there to help with boxing and unboxing of flag values.
     func flagValue<Value>(key: String) -> Value? where Value: FlagValue

--- a/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
+++ b/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
@@ -59,8 +59,8 @@ public protocol NonSendableFlagValueSource {
 
 }
 
-extension NonSendableFlagValueSource where Self: Identifiable, ID == String {
-    public var flagValueSourceID: String {
+public extension NonSendableFlagValueSource where Self: Identifiable, ID == String {
+    var flagValueSourceID: String {
         id
     }
 }

--- a/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
@@ -25,6 +25,11 @@ import UIKit
 /// Provides support for using `UserDefaults` as a `FlagValueSource`
 extension UserDefaults: NonSendableFlagValueSource {
 
+    /// A unique identifier for the flag value source.
+    public var flagValueSourceID: String {
+        name
+    }
+
     /// The name of the Flag Value Source
     public var name: String {
         "UserDefaults\(self == UserDefaults.standard ? ".standard" : "")"

--- a/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
@@ -27,11 +27,11 @@ extension UserDefaults: NonSendableFlagValueSource {
 
     /// A unique identifier for the flag value source.
     public var flagValueSourceID: String {
-        name
+        flagValueSourceName
     }
 
     /// The name of the Flag Value Source
-    public var name: String {
+    public var flagValueSourceName: String {
         "UserDefaults\(self == UserDefaults.standard ? ".standard" : "")"
     }
 

--- a/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
@@ -67,7 +67,7 @@ extension UserDefaults: NonSendableFlagValueSource {
 
     public typealias ChangeStream = AsyncMapSequence<NotificationCenter.Notifications, FlagChange>
 
-    public var changes: ChangeStream {
+    public var flagValueChanges: ChangeStream {
         NotificationCenter.default.notifications(named: UserDefaults.didChangeNotification, object: self)
             .map { _ in
                 FlagChange.all
@@ -78,7 +78,7 @@ extension UserDefaults: NonSendableFlagValueSource {
 
     public typealias ChangeStream = AsyncMapSequence<AsyncChain2Sequence<NotificationCenter.Notifications, NotificationCenter.Notifications>, FlagChange>
 
-    public var changes: ChangeStream {
+    public var flagValueChanges: ChangeStream {
         chain(
             NotificationCenter.default.notifications(named: UserDefaults.didChangeNotification, object: self),
 
@@ -94,7 +94,7 @@ extension UserDefaults: NonSendableFlagValueSource {
 
     public typealias ChangeStream = AsyncMapSequence<AsyncChain2Sequence<NotificationCenter.Notifications, NotificationCenter.Notifications>, FlagChange>
 
-    public var changes: ChangeStream {
+    public var flagValueChanges: ChangeStream {
         chain(
             NotificationCenter.default.notifications(named: UserDefaults.didChangeNotification, object: self),
 
@@ -109,7 +109,7 @@ extension UserDefaults: NonSendableFlagValueSource {
 #else
 
     /// No support for real-time flag publishing with `UserDefaults` on Linux
-    public var changes: EmptyFlagChangeStream {
+    public var flagValueChanges: EmptyFlagChangeStream {
         .init()
     }
 

--- a/Sources/Vexil/StreamManager.swift
+++ b/Sources/Vexil/StreamManager.swift
@@ -101,7 +101,7 @@ extension FlagPole {
     private func makeSubscribeTask(for source: some FlagValueSource) -> Task<Void, Never> {
         .detached(priority: .low) { [manager] in
             do {
-                for try await change in source.changes {
+                for try await change in source.flagValueChanges {
                     manager.withLock {
                         $0.stream?.send(change)
                     }

--- a/Sources/Vexil/StreamManager.swift
+++ b/Sources/Vexil/StreamManager.swift
@@ -63,7 +63,7 @@ extension FlagPole {
     }
 
     func subscribeChannel(oldSources: [any FlagValueSource], newSources: [any FlagValueSource], on manager: inout StreamManager, isInitialSetup: Bool = false) {
-        let difference = newSources.difference(from: oldSources, by: { $0.id == $1.id })
+        let difference = newSources.difference(from: oldSources, by: { $0.flagValueSourceID == $1.flagValueSourceID })
         var didChange = false
 
         // If a source has been removed, cancel any streams using it
@@ -71,7 +71,7 @@ extension FlagPole {
             didChange = true
             for removal in difference.removals {
                 manager.tasks.removeAll { task in
-                    if task.0 == removal.element.id {
+                    if task.0 == removal.element.flagValueSourceID {
                         task.1.cancel()
                         return true
                     } else {
@@ -86,7 +86,7 @@ extension FlagPole {
             didChange = true
             for insertion in difference.insertions {
                 manager.tasks.append(
-                    (insertion.element.id, makeSubscribeTask(for: insertion.element))
+                    (insertion.element.flagValueSourceID, makeSubscribeTask(for: insertion.element))
                 )
             }
         }

--- a/Sources/Vexillographer/FlagDetailView.swift
+++ b/Sources/Vexillographer/FlagDetailView.swift
@@ -84,7 +84,7 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
             if manager.source != nil {
                 FlagDetailSection(header: Text("Current Source")) {
                     HStack {
-                        Text(manager.source!.name)
+                        Text(manager.source!.flagValueSourceName)
                             .font(.headline)
                         Spacer()
                         description(source: manager.source!)
@@ -102,13 +102,13 @@ struct FlagDetailView<Value, RootGroup>: View where Value: FlagValue, RootGroup:
             }
 
             FlagDetailSection(header: Text("FlagPole Source Hierarchy")) {
-                ForEach(manager.flagPole._sources, id: \.name) { source in
+                ForEach(manager.flagPole._sources, id: \.flagValueSourceName) { source in
                     HStack {
                         if (source as AnyObject) === (manager.source as AnyObject) {
-                            Text(source.name)
+                            Text(source.flagValueSourceName)
                                 .font(.headline)
                         } else {
-                            Text(source.name)
+                            Text(source.flagValueSourceName)
                         }
                         Spacer()
                         description(source: source)

--- a/Sources/Vexillographer/FlagView.swift
+++ b/Sources/Vexillographer/FlagView.swift
@@ -55,22 +55,22 @@ struct UnfurledFlagView<Value, RootGroup>: View where Value: FlagValue, RootGrou
     var content: some View {
 
         if let flag = flag as? BooleanEditableFlag {
-            return flag.control(label: self.flag.info.name, manager: manager, showDetail: $showDetail)
+            return flag.control(label: self.flag.info.flagValueSourceName, manager: manager, showDetail: $showDetail)
 
         } else if let flag = flag as? OptionalBooleanEditableFlag {
-            return flag.control(label: self.flag.info.name, manager: manager, showDetail: $showDetail)
+            return flag.control(label: self.flag.info.flagValueSourceName, manager: manager, showDetail: $showDetail)
 
         } else if let flag = flag as? CaseIterableEditableFlag {
-            return flag.control(label: self.flag.info.name, manager: manager, showDetail: $showDetail)
+            return flag.control(label: self.flag.info.flagValueSourceName, manager: manager, showDetail: $showDetail)
 
         } else if let flag = flag as? OptionalCaseIterableEditableFlag {
-            return flag.control(label: self.flag.info.name, manager: manager, showDetail: $showDetail)
+            return flag.control(label: self.flag.info.flagValueSourceName, manager: manager, showDetail: $showDetail)
 
         } else if let flag = flag as? StringEditableFlag {
-            return flag.control(label: self.flag.info.name, manager: manager, showDetail: $showDetail)
+            return flag.control(label: self.flag.info.flagValueSourceName, manager: manager, showDetail: $showDetail)
 
         } else if let flag = flag as? OptionalStringEditableFlag {
-            return flag.control(label: self.flag.info.name, manager: manager, showDetail: $showDetail)
+            return flag.control(label: self.flag.info.flagValueSourceName, manager: manager, showDetail: $showDetail)
         }
 
         return EmptyView().eraseToAnyView()

--- a/Sources/Vexillographer/Unfurling/Unfurlable.swift
+++ b/Sources/Vexillographer/Unfurling/Unfurlable.swift
@@ -35,7 +35,7 @@ extension Flag: Unfurlable where Value: FlagValue {
         guard info.shouldDisplay == true else {
             return nil
         }
-        let unfurled = UnfurledFlag(name: info.name ?? label.localizedDisplayName, flag: self, manager: manager)
+        let unfurled = UnfurledFlag(name: info.flagValueSourceName ?? label.localizedDisplayName, flag: self, manager: manager)
         return unfurled.isEditable ? unfurled : nil
     }
 }
@@ -49,7 +49,7 @@ extension FlagGroup: Unfurlable {
         guard info.shouldDisplay == true else {
             return nil
         }
-        let unfurled = UnfurledFlagGroup(name: info.name ?? label.localizedDisplayName, group: self, manager: manager)
+        let unfurled = UnfurledFlagGroup(name: info.flagValueSourceName ?? label.localizedDisplayName, group: self, manager: manager)
         return unfurled.isEditable ? unfurled : nil
     }
 }

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagGroup.swift
@@ -88,20 +88,20 @@ struct UnfurledFlagGroup<Group, Root>: UnfurledFlagItem, Identifiable where Grou
 #if os(iOS)
 
         destination = destination
-            .navigationBarTitle(Text(info.name), displayMode: .inline)
+            .navigationBarTitle(Text(info.flagValueSourceName), displayMode: .inline)
             .eraseToAnyView()
 
 #elseif compiler(>=5.3.1)
 
         destination = destination
-            .navigationTitle(info.name)
+            .navigationTitle(info.flagValueSourceName)
             .eraseToAnyView()
 
 #endif
 
         return NavigationLink(destination: destination) {
             HStack {
-                Text(info.name)
+                Text(info.flagValueSourceName)
                     .font(.headline)
             }
         }.eraseToAnyView()

--- a/Sources/Vexillographer/Unfurling/UnfurledFlagInfo.swift
+++ b/Sources/Vexillographer/Unfurling/UnfurledFlagInfo.swift
@@ -34,7 +34,7 @@ struct UnfurledFlagInfo {
 
     init(key: String, info: FlagInfo, defaultName: String) {
         self.key = key
-        self.name = info.name ?? defaultName
+        self.name = info.flagValueSourceName ?? defaultName
         self.description = info.description
     }
 }

--- a/Tests/VexilTests/FlagValueCompilationTests.swift
+++ b/Tests/VexilTests/FlagValueCompilationTests.swift
@@ -69,7 +69,7 @@ final class FlagValueCompilationTests: XCTestCase {
                 fatalError()
             }
 
-            var changes: EmptyFlagChangeStream {
+            var flagValueChanges: EmptyFlagChangeStream {
                 .init()
             }
         }

--- a/Tests/VexilTests/FlagValueCompilationTests.swift
+++ b/Tests/VexilTests/FlagValueCompilationTests.swift
@@ -59,7 +59,7 @@ final class FlagValueCompilationTests: XCTestCase {
     func testDateFlagValue() {
         final class TestSource: FlagValueSource {
             let flagValueSourceID = UUID().uuidString
-            let name: String = "Test"
+            let flagValueSourceName: String = "Test"
             let value = Date.now
             func flagValue<Value>(key: String) -> Value? where Value: FlagValue {
                 Value(boxedFlagValue: value.boxedFlagValue)

--- a/Tests/VexilTests/FlagValueCompilationTests.swift
+++ b/Tests/VexilTests/FlagValueCompilationTests.swift
@@ -57,8 +57,9 @@ final class FlagValueCompilationTests: XCTestCase {
     }
 
     func testDateFlagValue() {
-        class TestSource: NonSendableFlagValueSource {
-            let name = "Test"
+        final class TestSource: FlagValueSource {
+            let flagValueSourceID = UUID().uuidString
+            let name: String = "Test"
             let value = Date.now
             func flagValue<Value>(key: String) -> Value? where Value: FlagValue {
                 Value(boxedFlagValue: value.boxedFlagValue)
@@ -74,7 +75,7 @@ final class FlagValueCompilationTests: XCTestCase {
         }
 
         let source = TestSource()
-        let pole = FlagPole(hoist: DateTestFlags.self, sources: [ FlagValueSourceCoordinator(source: source) ])
+        let pole = FlagPole(hoist: DateTestFlags.self, sources: [ source ])
         XCTAssertEqual(pole.flag.timeIntervalSinceReferenceDate, source.value.timeIntervalSinceReferenceDate, accuracy: 0.1)
     }
 

--- a/Tests/VexilTests/FlagValueSourceTests.swift
+++ b/Tests/VexilTests/FlagValueSourceTests.swift
@@ -130,6 +130,7 @@ private struct Subgroup {
 
 private final class TestGetSource: FlagValueSource {
 
+    let flagValueSourceID = UUID().uuidString
     let name = "Test Source"
     let subject: @Sendable (String) -> Void
     let values: [String: Bool]
@@ -157,6 +158,7 @@ private final class TestSetSource: FlagValueSource {
 
     typealias Event = (String, Bool)
 
+    let flagValueSourceID = UUID().uuidString
     let name = "Test Source"
     let subject: @Sendable (Event) -> Void
 

--- a/Tests/VexilTests/FlagValueSourceTests.swift
+++ b/Tests/VexilTests/FlagValueSourceTests.swift
@@ -131,7 +131,7 @@ private struct Subgroup {
 private final class TestGetSource: FlagValueSource {
 
     let flagValueSourceID = UUID().uuidString
-    let name = "Test Source"
+    let flagValueSourceName = "Test Source"
     let subject: @Sendable (String) -> Void
     let values: [String: Bool]
 
@@ -159,7 +159,7 @@ private final class TestSetSource: FlagValueSource {
     typealias Event = (String, Bool)
 
     let flagValueSourceID = UUID().uuidString
-    let name = "Test Source"
+    let flagValueSourceName = "Test Source"
     let subject: @Sendable (Event) -> Void
 
     init(subject: @escaping @Sendable (Event) -> Void) {

--- a/Tests/VexilTests/FlagValueSourceTests.swift
+++ b/Tests/VexilTests/FlagValueSourceTests.swift
@@ -147,7 +147,7 @@ private final class TestGetSource: FlagValueSource {
 
     func setFlagValue(_ value: (some FlagValue)?, key: String) throws {}
 
-    var changes: EmptyFlagChangeStream {
+    var flagValueChanges: EmptyFlagChangeStream {
         .init()
     }
 
@@ -177,7 +177,7 @@ private final class TestSetSource: FlagValueSource {
         subject((key, value))
     }
 
-    var changes: EmptyFlagChangeStream {
+    var flagValueChanges: EmptyFlagChangeStream {
         .init()
     }
 

--- a/Tests/VexilTests/PublisherTests.swift
+++ b/Tests/VexilTests/PublisherTests.swift
@@ -197,6 +197,7 @@ private struct TestFlags {
 }
 
 private final class TestSource: FlagValueSource {
+    let flagValueSourceID = UUID().uuidString
     let name = "Test Source"
 
     let stream: AsyncStream<FlagChange>

--- a/Tests/VexilTests/PublisherTests.swift
+++ b/Tests/VexilTests/PublisherTests.swift
@@ -198,7 +198,7 @@ private struct TestFlags {
 
 private final class TestSource: FlagValueSource {
     let flagValueSourceID = UUID().uuidString
-    let name = "Test Source"
+    let flagValueSourceName = "Test Source"
 
     let stream: AsyncStream<FlagChange>
     let continuation: AsyncStream<FlagChange>.Continuation

--- a/Tests/VexilTests/PublisherTests.swift
+++ b/Tests/VexilTests/PublisherTests.swift
@@ -215,7 +215,7 @@ private final class TestSource: FlagValueSource {
 
     func setFlagValue(_ value: (some FlagValue)?, key: String) throws {}
 
-    var changes: AsyncStream<FlagChange> {
+    var flagValueChanges: AsyncStream<FlagChange> {
         stream
     }
 


### PR DESCRIPTION
### 📒 Description

This PR makes a few changes to `FlagValueSource` and `NonSendableFlagValueSource`:

- Adds an explicit `flagValueSourceID` property instead of trying to piggy back off `Identifiable`.
- Renames `name` to `flagValueSourceName` to better disambiguate with other existing properties called `name` that a type you are trying to conform to `FlagValueSource` might have.
- Renames `changes` to `flagValueChanges` to better disambiguate with other existing properties called `changes` that a type you are trying to conform to `FlagValueSource` might have.

These changes resolve some errors building with Xcode 16 but are also just being a good citizen. We shouldn't be trying to force `Identifiable` on a type that just wants to be a `FlagValueSource` when all we need is an ID we can use for managing subscriptions.

This is part of the Vexil 3 alpha series.