### PR TITLE
Minor updates to async sequences

### DIFF
--- a/Sources/Vexil/Observability/Observing.swift
+++ b/Sources/Vexil/Observability/Observing.swift
@@ -33,6 +33,7 @@ public typealias FlagChangeStream = AsyncStream<FlagChange>
 public struct FilteredFlagChangeStream: AsyncSequence, Sendable {
 
     public typealias Element = FlagChange
+    public typealias Failure = Never
 
     let sequence: AsyncFilterSequence<FlagChangeStream>
 
@@ -49,8 +50,25 @@ public struct FilteredFlagChangeStream: AsyncSequence, Sendable {
         }
     }
 
-    public func makeAsyncIterator() -> AsyncFilterSequence<FlagChangeStream>.AsyncIterator {
-        sequence.makeAsyncIterator()
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        var iterator: AsyncFilterSequence<FlagChangeStream>.AsyncIterator
+
+        public mutating func next() async -> Element? {
+            await iterator.next()
+        }
+
+#if swift(>=6)
+        @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+        public mutating func next(
+            isolation actor: isolated (any Actor)?
+        ) async -> FlagChange? {
+            await iterator.next(isolation: actor)
+        }
+#endif
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(iterator: sequence.makeAsyncIterator())
     }
 
 }
@@ -62,6 +80,7 @@ public struct FilteredFlagChangeStream: AsyncSequence, Sendable {
 public struct EmptyFlagChangeStream: AsyncSequence, Sendable {
 
     public typealias Element = FlagChange
+    public typealias Failure = Never
 
     public init() {
         // Intentionally left blank
@@ -75,10 +94,18 @@ public struct EmptyFlagChangeStream: AsyncSequence, Sendable {
 
         public typealias Element = FlagChange
 
-        public func next() async throws -> FlagChange? {
+        public func next() async -> FlagChange? {
             nil
         }
 
+#if swift(>=6)
+        @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+        public func next(
+            isolation actor: isolated (any Actor)?
+        ) async -> FlagChange? {
+            nil
+        }
+#endif
     }
 
 }

--- a/Sources/Vexil/Value.swift
+++ b/Sources/Vexil/Value.swift
@@ -67,7 +67,7 @@ public protocol FlagDisplayValue {
 ///
 /// Any custom type you conform to `FlagValue` must be able to be represented using one of these types
 ///
-public enum BoxedFlagValue: Equatable & Sendable {
+public enum BoxedFlagValue: Equatable, Sendable {
     case array([BoxedFlagValue])
     case bool(Bool)
     case dictionary([String: BoxedFlagValue])


### PR DESCRIPTION
### 📒 Description

* Hide the iterator type of `FilteredFlagChangeStream` to make it robust to future changes
* Add swift 6 definitions of `Failure` and `next()` to async iterators
* `FlagChangeStream` can't throw, so `EmptyFlagChangeStream` shouldn't be able to either

### 🗳 Test Plan

Unit tests

### 🧯 Source Impact

Only affects unreleased Vexil 3 API

### ✅ Checklist

- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary