### PR TITLE
Don't generate Equatable checking for computed properties

### DIFF
--- a/Sources/VexilMacros/FlagContainerMacro.swift
+++ b/Sources/VexilMacros/FlagContainerMacro.swift
@@ -146,7 +146,7 @@ extension FlagContainerMacro: ExtensionMacro {
                     extendedType: type,
                     inheritanceClause: .init(inheritedTypes: [ .init(type: TypeSyntax(stringLiteral: "Equatable")) ])
                 ) {
-                    var variables = declaration.memberBlock.variables
+                    var variables = declaration.memberBlock.storedVariables
                     if variables.isEmpty == false {
                         try FunctionDeclSyntax("func ==(lhs: \(type), rhs: \(type)) -> Bool") {
                             if let lastBinding = variables.removeLast().bindings.first?.pattern {

--- a/Sources/VexilMacros/Utilities/SimpleVariables.swift
+++ b/Sources/VexilMacros/Utilities/SimpleVariables.swift
@@ -22,6 +22,29 @@ extension MemberBlockSyntax {
         }
     }
 
+    var storedVariables: [VariableDeclSyntax] {
+        variables.filter { variable in
+            // Only simple properties
+            guard variable.bindings.count == 1, let binding = variable.bindings.first else {
+                return false
+            }
+
+            // If it has no accessor block it's stored
+            guard let accessorBlock = binding.accessorBlock else {
+                return true
+            }
+
+            // If there is any kind of getter then its computed
+            switch accessorBlock.accessors {
+            case .getter:
+                return false
+
+            case let .accessors(accessors):
+                return accessors.allSatisfy({ $0.accessorSpecifier.tokenKind != .keyword(.get) })
+            }
+        }
+    }
+
 }
 
 extension VariableDeclSyntax {

--- a/Sources/VexilMacros/Utilities/SimpleVariables.swift
+++ b/Sources/VexilMacros/Utilities/SimpleVariables.swift
@@ -40,7 +40,7 @@ extension MemberBlockSyntax {
                 return false
 
             case let .accessors(accessors):
-                return accessors.allSatisfy({ $0.accessorSpecifier.tokenKind != .keyword(.get) })
+                return accessors.allSatisfy { $0.accessorSpecifier.tokenKind != .keyword(.get) }
             }
         }
     }

--- a/Tests/VexilMacroTests/EquatableFlagContainerMacroTests.swift
+++ b/Tests/VexilMacroTests/EquatableFlagContainerMacroTests.swift
@@ -64,6 +64,19 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
             struct TestFlags {
                 @Flag(default: false, description: "Some Flag")
                 var someFlag: Bool
+            
+                var someComputedNotEquatableProperty: (any Error)? {
+                    nil
+                }
+            
+                var someComputedPropertyWithAGetter: (any Error)? {
+                    get { fatalError() }
+                    set { fatalError() }
+                }
+            
+                var otherStoredProperty: Int {
+                    didSet { fatalError() }
+                }
             }
             """,
             expandedSource: """
@@ -84,6 +97,19 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
                         displayOption: .default,
                         lookup: _flagLookup
                     )
+                }
+            
+                var someComputedNotEquatableProperty: (any Error)? {
+                    nil
+                }
+            
+                var someComputedPropertyWithAGetter: (any Error)? {
+                    get { fatalError() }
+                    set { fatalError() }
+                }
+            
+                var otherStoredProperty: Int {
+                    didSet { fatalError() }
                 }
 
                 fileprivate let _flagKeyPath: FlagKeyPath
@@ -120,7 +146,8 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
 
             extension TestFlags: Equatable {
                 static func ==(lhs: TestFlags, rhs: TestFlags) -> Bool {
-                    lhs.someFlag == rhs.someFlag
+                    lhs.someFlag == rhs.someFlag &&
+                    lhs.otherStoredProperty == rhs.otherStoredProperty
                 }
             }
             """,

--- a/Tests/VexilMacroTests/EquatableFlagContainerMacroTests.swift
+++ b/Tests/VexilMacroTests/EquatableFlagContainerMacroTests.swift
@@ -64,16 +64,16 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
             struct TestFlags {
                 @Flag(default: false, description: "Some Flag")
                 var someFlag: Bool
-            
+
                 var someComputedNotEquatableProperty: (any Error)? {
                     nil
                 }
-            
+
                 var someComputedPropertyWithAGetter: (any Error)? {
                     get { fatalError() }
                     set { fatalError() }
                 }
-            
+
                 var otherStoredProperty: Int {
                     didSet { fatalError() }
                 }
@@ -98,16 +98,16 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
                         lookup: _flagLookup
                     )
                 }
-            
+
                 var someComputedNotEquatableProperty: (any Error)? {
                     nil
                 }
-            
+
                 var someComputedPropertyWithAGetter: (any Error)? {
                     get { fatalError() }
                     set { fatalError() }
                 }
-            
+
                 var otherStoredProperty: Int {
                     didSet { fatalError() }
                 }


### PR DESCRIPTION
### 📒 Description

The `@FlagContainer` macro generates Equatable conformance by default for all properties, including computed properties. This is not consistent with how the compiler synthesises it. This PR changes the macro so we only generate comparisons for stored properties.