### PR TITLE
Added support for omitting the default parameter/initialiser for optional flag types.

### DIFF
--- a/Tests/VexilMacroTests/FlagMacroTests.swift
+++ b/Tests/VexilMacroTests/FlagMacroTests.swift
@@ -162,6 +162,41 @@ final class FlagMacroTests: XCTestCase {
         )
     }
 
+    func testExpandsOptional() throws {
+        assertMacroExpansion(
+            """
+            struct TestFlags {
+                @Flag(description: "meow")
+                var testProperty: Bool?
+            }
+            """,
+            expandedSource:
+            """
+            struct TestFlags {
+                var testProperty: Bool? {
+                    get {
+                        _flagLookup.value(for: _flagKeyPath.append(.automatic("test-property"))) ?? nil
+                    }
+                }
+
+                var $testProperty: FlagWigwag<Bool?> {
+                    FlagWigwag(
+                        keyPath: _flagKeyPath.append(.automatic("test-property")),
+                        name: nil,
+                        defaultValue: nil,
+                        description: "meow",
+                        displayOption: .default,
+                        lookup: _flagLookup
+                    )
+                }
+            }
+            """,
+            macros: [
+                "Flag": FlagMacro.self,
+            ]
+        )
+    }
+
 
     // MARK: - Property Initialisation Tests
 


### PR DESCRIPTION
### 📒 Description

The Vexil 3 `@Flag` macro had a bit of a gap with initialising:

```swift
@Flag(default: nil, description: "Some flag")
var someFlag: SomeType?
```

Because the macro is declared as a generic, and the `nil` literal has no type to satisfy it. This forced you to provide an initialiser, but then a lot of linters complain about unnecessary `nil` initialisers.

This PR allows for omitting the default value and the initialiser, so long as the type is optional.