### PR TITLE
Support public Wigwags

### DIFF
--- a/Sources/VexilMacros/FlagContainerMacro.swift
+++ b/Sources/VexilMacros/FlagContainerMacro.swift
@@ -186,7 +186,7 @@ extension FlagContainerMacro: ExtensionMacro {
 
 // MARK: - Scopes
 
-private extension DeclModifierListSyntax {
+extension DeclModifierListSyntax {
     var scopeSyntax: DeclModifierListSyntax {
         filter { modifier in
             if case let .keyword(keyword) = modifier.name.tokenKind, keyword == .public {

--- a/Sources/VexilMacros/FlagGroupMacro.swift
+++ b/Sources/VexilMacros/FlagGroupMacro.swift
@@ -25,6 +25,7 @@ public struct FlagGroupMacro {
     let description: ExprSyntax?
     let displayOption: ExprSyntax?
     let type: TypeSyntax
+    let scopes: DeclModifierListSyntax
 
 
     // MARK: - Initialisation
@@ -52,6 +53,7 @@ public struct FlagGroupMacro {
         self.propertyName = identifier.text
         self.key = strategy.createKey(propertyName)
         self.type = type
+        self.scopes = property.modifiers.scopeSyntax
 
         self.name = arguments[label: "name"]?.expression
         self.description = arguments[label: "description"]?.expression
@@ -90,6 +92,21 @@ public struct FlagGroupMacro {
         }
     }
 
+    func makeWigwagDeclaration() throws -> VariableDeclSyntax {
+        return try VariableDeclSyntax("var $\(raw: propertyName): FlagGroupWigwag<\(type)>") {
+            """
+            FlagGroupWigwag(
+                keyPath: \(key),
+                name: \(name ?? "nil"),
+                description: \(description ?? "nil"),
+                displayOption: \(displayOption ?? ".navigation"),
+                lookup: _flagLookup
+            )
+            """
+        }
+        .with(\.modifiers, scopes)
+    }
+
 }
 
 extension FlagGroupMacro: AccessorMacro {
@@ -120,17 +137,7 @@ extension FlagGroupMacro: PeerMacro {
         do {
             let macro = try FlagGroupMacro(node: node, declaration: declaration, context: context)
             return [
-                """
-                var $\(raw: macro.propertyName): FlagGroupWigwag<\(macro.type)> {
-                    FlagGroupWigwag(
-                        keyPath: \(macro.key),
-                        name: \(macro.name ?? "nil"),
-                        description: \(macro.description ?? "nil"),
-                        displayOption: \(macro.displayOption ?? ".navigation"),
-                        lookup: _flagLookup
-                    )
-                }
-                """,
+                try DeclSyntax(macro.makeWigwagDeclaration()),
             ]
         } catch {
             return []

--- a/Sources/VexilMacros/FlagGroupMacro.swift
+++ b/Sources/VexilMacros/FlagGroupMacro.swift
@@ -93,7 +93,7 @@ public struct FlagGroupMacro {
     }
 
     func makeWigwagDeclaration() throws -> VariableDeclSyntax {
-        return try VariableDeclSyntax("var $\(raw: propertyName): FlagGroupWigwag<\(type)>") {
+        try VariableDeclSyntax("var $\(raw: propertyName): FlagGroupWigwag<\(type)>") {
             """
             FlagGroupWigwag(
                 keyPath: \(key),
@@ -136,8 +136,8 @@ extension FlagGroupMacro: PeerMacro {
     ) throws -> [DeclSyntax] {
         do {
             let macro = try FlagGroupMacro(node: node, declaration: declaration, context: context)
-            return [
-                try DeclSyntax(macro.makeWigwagDeclaration()),
+            return try [
+                DeclSyntax(macro.makeWigwagDeclaration()),
             ]
         } catch {
             return []

--- a/Sources/VexilMacros/FlagMacro.swift
+++ b/Sources/VexilMacros/FlagMacro.swift
@@ -103,7 +103,7 @@ public struct FlagMacro {
     }
 
     func makeWigwagDeclaration() throws -> VariableDeclSyntax {
-        return try VariableDeclSyntax("var $\(raw: propertyName): FlagWigwag<\(type)>") {
+        try VariableDeclSyntax("var $\(raw: propertyName): FlagWigwag<\(type)>") {
             """
             FlagWigwag(
                 keyPath: \(key),
@@ -171,8 +171,8 @@ extension FlagMacro: PeerMacro {
     ) throws -> [DeclSyntax] {
         do {
             let macro = try FlagMacro(node: node, declaration: declaration, context: context)
-            return [
-                try DeclSyntax(macro.makeWigwagDeclaration()),
+            return try [
+                DeclSyntax(macro.makeWigwagDeclaration()),
             ]
         } catch {
             return []

--- a/Sources/VexilMacros/FlagMacro.swift
+++ b/Sources/VexilMacros/FlagMacro.swift
@@ -27,6 +27,7 @@ public struct FlagMacro {
     let description: ExprSyntax
     let display: ExprSyntax?
     let type: TypeSyntax
+    let scopes: DeclModifierListSyntax
 
 
     // MARK: - Initialisation
@@ -54,6 +55,7 @@ public struct FlagMacro {
         else {
             throw DiagnosticsError(diagnostics: [ .init(node: node, message: Diagnostic.onlySimpleVariableSupported) ])
         }
+        self.scopes = property.modifiers.scopeSyntax
 
         var defaultExprSyntax: ExprSyntax
         if let defaultExpr = arguments[label: "default"]?.expression ?? binding.initializer?.value {
@@ -98,6 +100,22 @@ public struct FlagMacro {
             wigwag: { [self] in $\(raw: propertyName) }
         )
         """
+    }
+
+    func makeWigwagDeclaration() throws -> VariableDeclSyntax {
+        return try VariableDeclSyntax("var $\(raw: propertyName): FlagWigwag<\(type)>") {
+            """
+            FlagWigwag(
+                keyPath: \(key),
+                name: \(name ?? "nil"),
+                defaultValue: \(defaultValue),
+                description: \(description),
+                displayOption: \(display ?? ".default"),
+                lookup: _flagLookup
+            )
+            """
+        }
+        .with(\.modifiers, scopes)
     }
 
 }
@@ -154,18 +172,7 @@ extension FlagMacro: PeerMacro {
         do {
             let macro = try FlagMacro(node: node, declaration: declaration, context: context)
             return [
-                """
-                var $\(raw: macro.propertyName): FlagWigwag<\(macro.type)> {
-                    FlagWigwag(
-                        keyPath: \(macro.key),
-                        name: \(macro.name ?? "nil"),
-                        defaultValue: \(macro.defaultValue),
-                        description: \(macro.description),
-                        displayOption: \(macro.display ?? ".default"),
-                        lookup: _flagLookup
-                    )
-                }
-                """,
+                try DeclSyntax(macro.makeWigwagDeclaration()),
             ]
         } catch {
             return []

--- a/Tests/VexilMacroTests/FlagGroupMacroTests.swift
+++ b/Tests/VexilMacroTests/FlagGroupMacroTests.swift
@@ -54,6 +54,41 @@ final class FlagGroupMacroTests: XCTestCase {
         )
     }
 
+    func testExpandsPublic() throws {
+        assertMacroExpansion(
+            """
+            struct TestFlags {
+                @FlagGroup(description: "Test Flag Group")
+                public var testSubgroup: SubgroupFlags
+            }
+            """,
+            expandedSource:
+            """
+            struct TestFlags {
+                public var testSubgroup: SubgroupFlags {
+                    get {
+                        SubgroupFlags(_flagKeyPath: _flagKeyPath.append(.automatic("test-subgroup")), _flagLookup: _flagLookup)
+                    }
+                }
+
+                public var $testSubgroup: FlagGroupWigwag<SubgroupFlags> {
+                    FlagGroupWigwag(
+                        keyPath: _flagKeyPath.append(.automatic("test-subgroup")),
+                        name: nil,
+                        description: "Test Flag Group",
+                        displayOption: .navigation,
+                        lookup: _flagLookup
+                    )
+                }
+            }
+            """,
+            macros: [
+                "FlagGroup": FlagGroupMacro.self,
+            ]
+        )
+    }
+
+
     // MARK: - Flag Group Detail Tests
 
     func testExpandsName() throws {

--- a/Tests/VexilMacroTests/FlagMacroTests.swift
+++ b/Tests/VexilMacroTests/FlagMacroTests.swift
@@ -197,6 +197,41 @@ final class FlagMacroTests: XCTestCase {
         )
     }
 
+    func testExpandsPublic() throws {
+        assertMacroExpansion(
+            """
+            struct TestFlags {
+                @Flag(default: false, description: "meow")
+                public var testProperty: Bool
+            }
+            """,
+            expandedSource:
+            """
+            struct TestFlags {
+                public var testProperty: Bool {
+                    get {
+                        _flagLookup.value(for: _flagKeyPath.append(.automatic("test-property"))) ?? false
+                    }
+                }
+
+                public var $testProperty: FlagWigwag<Bool> {
+                    FlagWigwag(
+                        keyPath: _flagKeyPath.append(.automatic("test-property")),
+                        name: nil,
+                        defaultValue: false,
+                        description: "meow",
+                        displayOption: .default,
+                        lookup: _flagLookup
+                    )
+                }
+            }
+            """,
+            macros: [
+                "Flag": FlagMacro.self,
+            ]
+        )
+    }
+
 
     // MARK: - Property Initialisation Tests
 


### PR DESCRIPTION
### 📒 Description

When attaching a `@Flag` or `@FlagGroup` to a public property, the macros were generating `internal` properties for the Wigwags. This PR updates the macro to match the scope of the attached property.