### PR TITLE
Make updating FlagPole's source list thread-safe.

### DIFF
--- a/Sources/Vexil/Observability/Observing.swift
+++ b/Sources/Vexil/Observability/Observing.swift
@@ -13,7 +13,7 @@
 
 import AsyncAlgorithms
 
-public enum FlagChange: Sendable {
+public enum FlagChange: Sendable, Equatable {
 
     /// All flags _may_ have changed. This change type often occurs when flags could be changed
     /// outside the bounds of the app using Vexil and we are unable to tell if any flags have changed,
@@ -108,4 +108,13 @@ public struct EmptyFlagChangeStream: AsyncSequence, Sendable {
 #endif
     }
 
+}
+
+extension FlagChange: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .all:              "FlagChange.all"
+        case let .some(keys):   "FlagChange.some(\(keys.map(\.key).joined(separator: ", ")))"
+        }
+    }
 }

--- a/Sources/Vexil/Sources/FlagValueDictionary.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary.swift
@@ -78,7 +78,7 @@ public final class FlagValueDictionary: Identifiable, ExpressibleByDictionaryLit
     // MARK: - Dictionary Access
 
     /// Returns a copy of the current values in this source
-    var allValues: DictionaryType {
+    public var allValues: DictionaryType {
         storage.withLock { $0 }
     }
 


### PR DESCRIPTION
### 📒 Description

Vexil 2 allowed direct manipulation of its source's via the setter on the `_sources` property. This was no thread safe since it involved a read, manipulation of a local copy, and then setting it. It also meant multiple step operations like finding + removing an existing `FlagValueSource` and replacing it would call the `didSet` observer multiple times if not careful, resulting in unnecessary snapshots and publishing.

This PR removes the direct setter in favour of an `updateSources` method that takes a closure and is passed a mutable copy of the sources array, which can be safely manipulated within the closer before being saved back again, and only one observer triggered.