### PR TITLE
Generate explicit Sendable conformance

### DIFF
--- a/Tests/VexilMacroTests/EquatableFlagContainerMacroTests.swift
+++ b/Tests/VexilMacroTests/EquatableFlagContainerMacroTests.swift
@@ -56,6 +56,9 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
                     true
                 }
             }
+
+            extension TestFlags: Sendable {
+            }
             """,
             macros: [
                 "FlagContainer": FlagContainerMacro.self,
@@ -156,6 +159,9 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
                     lhs.otherStoredProperty == rhs.otherStoredProperty
                 }
             }
+
+            extension TestFlags: Sendable {
+            }
             """,
             macros: [
                 "FlagContainer": FlagContainerMacro.self,
@@ -230,6 +236,9 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
                 public static func ==(lhs: TestFlags, rhs: TestFlags) -> Bool {
                     lhs.someFlag == rhs.someFlag
                 }
+            }
+
+            extension TestFlags: Sendable {
             }
             """,
             macros: [
@@ -309,6 +318,9 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
                     lhs.someFlag == rhs.someFlag
                 }
             }
+
+            extension SomeContainer.TestFlags: Sendable {
+            }
             """,
             macros: [
                 "FlagContainer": FlagContainerMacro.self,
@@ -382,6 +394,9 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
                 static func ==(lhs: TestFlags, rhs: TestFlags) -> Bool {
                     lhs.someFlag == rhs.someFlag
                 }
+            }
+
+            extension TestFlags: Sendable {
             }
             """,
             macros: [
@@ -478,6 +493,9 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
                     lhs.second == rhs.second
                 }
             }
+
+            extension TestFlags: Sendable {
+            }
             """,
             macros: [
                 "FlagContainer": FlagContainerMacro.self,
@@ -571,6 +589,9 @@ final class EquatableFlagContainerMacroTests: XCTestCase {
                     lhs.flagGroup == rhs.flagGroup &&
                     lhs.second == rhs.second
                 }
+            }
+
+            extension TestFlags: Sendable {
             }
             """,
             macros: [

--- a/Tests/VexilMacroTests/FlagContainerMacroTests.swift
+++ b/Tests/VexilMacroTests/FlagContainerMacroTests.swift
@@ -56,6 +56,9 @@ final class FlagContainerMacroTests: XCTestCase {
                     true
                 }
             }
+
+            extension TestFlags: Sendable {
+            }
             """,
             macros: [
                 "FlagContainer": FlagContainerMacro.self,
@@ -99,6 +102,9 @@ final class FlagContainerMacroTests: XCTestCase {
                     true
                 }
             }
+
+            extension TestFlags: Sendable {
+            }
             """,
             macros: [
                 "FlagContainer": FlagContainerMacro.self,
@@ -141,6 +147,9 @@ final class FlagContainerMacroTests: XCTestCase {
                 static func ==(lhs: TestFlags, rhs: TestFlags) -> Bool {
                     true
                 }
+            }
+
+            extension TestFlags: Sendable {
             }
             """,
             macros: [
@@ -237,6 +246,9 @@ final class FlagContainerMacroTests: XCTestCase {
                     lhs.flagGroup == rhs.flagGroup &&
                     lhs.second == rhs.second
                 }
+            }
+
+            extension TestFlags: Sendable {
             }
             """,
             macros: [


### PR DESCRIPTION
### 📒 Description

This PR fixes an issue seen in some codebases with Xcode 26.2 where `FlagContainer`'s inherited conformance to `Sendable` generates an error without explicit conformance being applied to the declaration.

This PR updates `@FlagContainer` to generate explicit `Sendable` conformance as an extension, resolving the errors. Like our other conformances, if the user adds their own `Sendable` conformance we skip it.
