### PR TITLE
Added FlagWigwag.value getter

### DIFF
--- a/Sources/Vexil/Observability/FlagWigwag.swift
+++ b/Sources/Vexil/Observability/FlagWigwag.swift
@@ -39,6 +39,11 @@ public struct FlagWigwag<Output>: Sendable where Output: FlagValue {
     /// The default value for this flag
     public let defaultValue: Output
 
+    /// The current resolved value of this flag
+    public var value: Output {
+        lookup.value(for: keyPath) ?? defaultValue
+    }
+
     /// A human readable name for the flag. Only visible in flag editors like Vexillographer.
     public let name: String
 


### PR DESCRIPTION
### 📒 Description

`FlagWigwag` is a way to get information about flags and to track changes to flags over time, eg:

```swift
let wigwag = flagPole.subgroup.$myFlag
```

The `FlagWigwag` has access be able to look up the current value as part of its internal workings, but if you wanted to get the current value you'd need to:

```swift
// Get it alongside the wigwag
let (value, wigwag) = (flagPole.subgroup.myFlag, flagPole.subgroup.$myFlag)

// Get it from a publisher or AsyncSequence
let value = wigwag.first() ?? wigwag.defaultValue
let value = await wigwag.first(where: { _ in true }) ?? wigwag.defaultValue
```

This PR adds a `FlagWigwag.value` getter to close this gap:

```swift
let wigwag = flagPole.subgroup.$myFlag
let value = wigwag.value
```