### PR TITLE
Fixed caching of FlagPole sources in Vexillographer

### DIFF
--- a/Examples/Examples/Dependencies.swift
+++ b/Examples/Examples/Dependencies.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Examples/Examples/DoubleAndBooleanControlStyle.swift
+++ b/Examples/Examples/DoubleAndBooleanControlStyle.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Examples/Examples/ExamplesApp.swift
+++ b/Examples/Examples/ExamplesApp.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Examples/Examples/FeatureFlags.swift
+++ b/Examples/Examples/FeatureFlags.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Examples/Examples/RootView.swift
+++ b/Examples/Examples/RootView.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Examples/ExamplesTests/ExamplesTests.swift
+++ b/Examples/ExamplesTests/ExamplesTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Configuration.swift
+++ b/Sources/Vexil/Configuration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Container.swift
+++ b/Sources/Vexil/Container.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/DisplayOptions.swift
+++ b/Sources/Vexil/DisplayOptions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Flag.swift
+++ b/Sources/Vexil/Flag.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Group.swift
+++ b/Sources/Vexil/Group.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/KeyPath.swift
+++ b/Sources/Vexil/KeyPath.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Lookup.swift
+++ b/Sources/Vexil/Lookup.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Observability/FlagGroupWigwag.swift
+++ b/Sources/Vexil/Observability/FlagGroupWigwag.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Observability/FlagWigwag.swift
+++ b/Sources/Vexil/Observability/FlagWigwag.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Observability/Observing.swift
+++ b/Sources/Vexil/Observability/Observing.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Pole+Observability.swift
+++ b/Sources/Vexil/Pole+Observability.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Pole.swift
+++ b/Sources/Vexil/Pole.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Pole.swift
+++ b/Sources/Vexil/Pole.swift
@@ -53,7 +53,7 @@ public final class FlagPole<RootGroup>: Sendable where RootGroup: FlagContainer 
     public let _configuration: VexilConfiguration
 
     /// Primary storage
-    let manager: Lock<StreamManager>
+    package let manager: Lock<StreamManager>
 
 
     // MARK: - Sources

--- a/Sources/Vexil/Snapshots/MutableFlagContainer.swift
+++ b/Sources/Vexil/Snapshots/MutableFlagContainer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Snapshots/Snapshot+Extensions.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+Extensions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Snapshots/Snapshot+FlagValueSource.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+FlagValueSource.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Snapshots/Snapshot+Lookup.swift
+++ b/Sources/Vexil/Snapshots/Snapshot+Lookup.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Snapshots/Snapshot.swift
+++ b/Sources/Vexil/Snapshots/Snapshot.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Snapshots/SnapshotBuilder.swift
+++ b/Sources/Vexil/Snapshots/SnapshotBuilder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Sources/BoxedFlagValue+NSObject.swift
+++ b/Sources/Vexil/Sources/BoxedFlagValue+NSObject.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary+FlagValueSource.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Sources/FlagValueDictionary.swift
+++ b/Sources/Vexil/Sources/FlagValueDictionary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Sources/FlagValueSource.swift
+++ b/Sources/Vexil/Sources/FlagValueSource.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Sources/FlagValueSourceCoordinator.swift
+++ b/Sources/Vexil/Sources/FlagValueSourceCoordinator.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/NSUbiquitousKeyValueStore+FlagValueSource.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
+++ b/Sources/Vexil/Sources/NonSendableFlagValueSource.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
+++ b/Sources/Vexil/Sources/UserDefaults+FlagValueSource.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/StreamManager.swift
+++ b/Sources/Vexil/StreamManager.swift
@@ -23,7 +23,7 @@ import AsyncAlgorithms
 ///                │   │           │  │
 ///     Source 3───┘   └───────────┘  └──► Subscriber 3
 ///
-struct StreamManager {
+package struct StreamManager {
 
     // MARK: - Properties
 
@@ -31,7 +31,7 @@ struct StreamManager {
     ///
     /// The order of this array is the order used when looking up flag values.
     ///
-    var sources: [any FlagValueSource]
+    package var sources: [any FlagValueSource]
 
     /// This channel acts as our central "Subject" (in Combine terms). The channel is
     /// listens to change streams coming from the various sources, and subscribers to this

--- a/Sources/Vexil/StreamManager.swift
+++ b/Sources/Vexil/StreamManager.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Utilities/AsyncCurrentValue.swift
+++ b/Sources/Vexil/Utilities/AsyncCurrentValue.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Utilities/BoxedFlagValue+Codable.swift
+++ b/Sources/Vexil/Utilities/BoxedFlagValue+Codable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Utilities/CollectionDifference.Change+Element.swift
+++ b/Sources/Vexil/Utilities/CollectionDifference.Change+Element.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Utilities/FlagChangeStream.swift
+++ b/Sources/Vexil/Utilities/FlagChangeStream.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Utilities/Lock.swift
+++ b/Sources/Vexil/Utilities/Lock.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Utilities/Lock.swift
+++ b/Sources/Vexil/Utilities/Lock.swift
@@ -42,24 +42,24 @@ struct Mutex<Value: ~Copyable>: ~Copyable, Sendable {
 /// This is a lock that will use the most appropriate platform lock under the hood. On Apple platforms
 /// it is effectively a wrapper around `OSAllocatedUnfairLock`. On non-Apple platforms it'll
 /// use `pthread_lock` and friends.
-struct Lock<State>: Sendable {
+package struct Lock<State>: Sendable {
 
     private let platformLock: PlatformLock<State>
 
-    init(uncheckedState: State) {
+    package init(uncheckedState: State) {
         nonisolated(unsafe) let initialState = uncheckedState
         self.platformLock = PlatformLock(initialState)
     }
 
-    init(initialState: State) where State: Sendable {
+    package init(initialState: State) where State: Sendable {
         self.platformLock = PlatformLock(initialState)
     }
 
-    init(_ initialState: State) where State: Sendable  {
+    package init(_ initialState: State) where State: Sendable  {
         self.platformLock = PlatformLock(initialState)
     }
 
-    func withLockUnchecked<R>(_ body: (inout State) throws -> R) rethrows -> R {
+    package func withLockUnchecked<R>(_ body: (inout State) throws -> R) rethrows -> R {
         try platformLock.withLock {
             var state = $0
             do {
@@ -73,7 +73,7 @@ struct Lock<State>: Sendable {
         }
     }
 
-    func withLock<R: Sendable>(_ body: @Sendable (inout State) throws -> R) rethrows -> R {
+    package func withLock<R: Sendable>(_ body: @Sendable (inout State) throws -> R) rethrows -> R {
         try withLockUnchecked(body)
     }
 

--- a/Sources/Vexil/Value.swift
+++ b/Sources/Vexil/Value.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Visitor.swift
+++ b/Sources/Vexil/Visitor.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Visitors/FlagDescriber.swift
+++ b/Sources/Vexil/Visitors/FlagDescriber.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Visitors/FlagRemover.swift
+++ b/Sources/Vexil/Visitors/FlagRemover.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexil/Visitors/FlagSetter.swift
+++ b/Sources/Vexil/Visitors/FlagSetter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/VexilMacros/FlagContainerMacro.swift
+++ b/Sources/VexilMacros/FlagContainerMacro.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/VexilMacros/FlagGroupMacro.swift
+++ b/Sources/VexilMacros/FlagGroupMacro.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/VexilMacros/FlagMacro.swift
+++ b/Sources/VexilMacros/FlagMacro.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/VexilMacros/Plugin.swift
+++ b/Sources/VexilMacros/Plugin.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/VexilMacros/Utilities/AttributeArgument.swift
+++ b/Sources/VexilMacros/Utilities/AttributeArgument.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/VexilMacros/Utilities/DisplayName.swift
+++ b/Sources/VexilMacros/Utilities/DisplayName.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/VexilMacros/Utilities/PatternBindingSyntax.swift
+++ b/Sources/VexilMacros/Utilities/PatternBindingSyntax.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/VexilMacros/Utilities/SimpleVariables.swift
+++ b/Sources/VexilMacros/Utilities/SimpleVariables.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/VexilMacros/Utilities/String+Snakecase.swift
+++ b/Sources/VexilMacros/Utilities/String+Snakecase.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagControl.swift
+++ b/Sources/Vexillographer/FlagControl/FlagControl.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagControlConfiguration.swift
+++ b/Sources/Vexillographer/FlagControl/FlagControlConfiguration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagDetail.swift
+++ b/Sources/Vexillographer/FlagControl/FlagDetail.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagPicker+Bool.swift
+++ b/Sources/Vexillographer/FlagControl/FlagPicker+Bool.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagPicker+CaseIterable.swift
+++ b/Sources/Vexillographer/FlagControl/FlagPicker+CaseIterable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagPicker.swift
+++ b/Sources/Vexillographer/FlagControl/FlagPicker.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagTextField+FloatingPoint.swift
+++ b/Sources/Vexillographer/FlagControl/FlagTextField+FloatingPoint.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagTextField+Integer.swift
+++ b/Sources/Vexillographer/FlagControl/FlagTextField+Integer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagTextField+String.swift
+++ b/Sources/Vexillographer/FlagControl/FlagTextField+String.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagTextField.swift
+++ b/Sources/Vexillographer/FlagControl/FlagTextField.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/FlagToggle.swift
+++ b/Sources/Vexillographer/FlagControl/FlagToggle.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagControl/RowContent.swift
+++ b/Sources/Vexillographer/FlagControl/RowContent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagPole/FlagGroupItem.swift
+++ b/Sources/Vexillographer/FlagPole/FlagGroupItem.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagPole/FlagItem.swift
+++ b/Sources/Vexillographer/FlagPole/FlagItem.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagPole/FlagPoleContext.swift
+++ b/Sources/Vexillographer/FlagPole/FlagPoleContext.swift
@@ -18,7 +18,10 @@ struct FlagPoleContext {
 
     var items: [any FlagPoleItem] = []
     var editableSource: (any FlagValueSource)?
-    var sources: [any FlagValueSource] = []
+    var streamManager: Lock<StreamManager>?
+    var sources: [any FlagValueSource] {
+        streamManager?.withLock { $0.sources } ?? []
+    }
     var keyPathByFlagKeyPath = [FlagKeyPath: AnyKeyPath]()
     var styles = [AnyHashable: any FlagControlStyle]()
 

--- a/Sources/Vexillographer/FlagPole/FlagPoleContext.swift
+++ b/Sources/Vexillographer/FlagPole/FlagPoleContext.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information
@@ -22,6 +22,7 @@ struct FlagPoleContext {
     var sources: [any FlagValueSource] {
         streamManager?.withLock { $0.sources } ?? []
     }
+
     var keyPathByFlagKeyPath = [FlagKeyPath: AnyKeyPath]()
     var styles = [AnyHashable: any FlagControlStyle]()
 

--- a/Sources/Vexillographer/FlagPole/FlagPoleItem.swift
+++ b/Sources/Vexillographer/FlagPole/FlagPoleItem.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagPole/FlagPoleItemGroup.swift
+++ b/Sources/Vexillographer/FlagPole/FlagPoleItemGroup.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/FlagPole/FlagPoleVisitor.swift
+++ b/Sources/Vexillographer/FlagPole/FlagPoleVisitor.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/Utilities/OptionalProtocol.swift
+++ b/Sources/Vexillographer/Utilities/OptionalProtocol.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/Vexillographer.swift
+++ b/Sources/Vexillographer/Vexillographer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/View+FlagControlStyle.swift
+++ b/Sources/Vexillographer/View+FlagControlStyle.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/View+FlagPole.swift
+++ b/Sources/Vexillographer/View+FlagPole.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Sources/Vexillographer/View+FlagPole.swift
+++ b/Sources/Vexillographer/View+FlagPole.swift
@@ -38,7 +38,7 @@ private struct FlagPoleModifier<RootGroup: FlagContainer>: ViewModifier {
                 $0.items = visitor.items
                 $0.keyPathByFlagKeyPath = visitor.keyPathByFlagKeyPath
                 $0.editableSource = editableSource
-                $0.sources = flagPole._sources
+                $0.streamManager = flagPole.manager
             }
     }
 }

--- a/Tests/VexilMacroTests/EquatableFlagContainerMacroTests.swift
+++ b/Tests/VexilMacroTests/EquatableFlagContainerMacroTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilMacroTests/FlagContainerMacroTests.swift
+++ b/Tests/VexilMacroTests/FlagContainerMacroTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilMacroTests/FlagGroupMacroTests.swift
+++ b/Tests/VexilMacroTests/FlagGroupMacroTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilMacroTests/FlagMacroTests.swift
+++ b/Tests/VexilMacroTests/FlagMacroTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/BoxedFlagValueDecodingTests.swift
+++ b/Tests/VexilTests/BoxedFlagValueDecodingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/BoxedFlagValueEncodingTests.swift
+++ b/Tests/VexilTests/BoxedFlagValueEncodingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/EquatableTests.swift
+++ b/Tests/VexilTests/EquatableTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/FlagDetailTests.swift
+++ b/Tests/VexilTests/FlagDetailTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/FlagPoleTests.swift
+++ b/Tests/VexilTests/FlagPoleTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/FlagValueBoxingTests.swift
+++ b/Tests/VexilTests/FlagValueBoxingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/FlagValueCompilationTests.swift
+++ b/Tests/VexilTests/FlagValueCompilationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/FlagValueDictionaryTests.swift
+++ b/Tests/VexilTests/FlagValueDictionaryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/FlagValueSourceTests.swift
+++ b/Tests/VexilTests/FlagValueSourceTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/FlagValueUnboxingTests.swift
+++ b/Tests/VexilTests/FlagValueUnboxingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/KeyEncodingTests.swift
+++ b/Tests/VexilTests/KeyEncodingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/PublisherTests.swift
+++ b/Tests/VexilTests/PublisherTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/SnapshotTests.swift
+++ b/Tests/VexilTests/SnapshotTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/UserDefaultPublisherTests.swift
+++ b/Tests/VexilTests/UserDefaultPublisherTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/UserDefaultsDecodingTests.swift
+++ b/Tests/VexilTests/UserDefaultsDecodingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/UserDefaultsEncodingTests.swift
+++ b/Tests/VexilTests/UserDefaultsEncodingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/Utilities/Tags.swift
+++ b/Tests/VexilTests/Utilities/Tags.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/Utilities/TestRunner.swift
+++ b/Tests/VexilTests/Utilities/TestRunner.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information

--- a/Tests/VexilTests/VisitorTests.swift
+++ b/Tests/VexilTests/VisitorTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Vexil open source project
 //
-// Copyright (c) 2025 Unsigned Apps and the open source contributors.
+// Copyright (c) 2026 Unsigned Apps and the open source contributors.
 // Licensed under the MIT license
 //
 // See LICENSE for license information


### PR DESCRIPTION
### 📒 Description

Fixes #147.

Vexillographer 3's `FlagPoleContext` was grabbing the array of sources when the FlagPole was added to the view hierarchy, so if the list of sources was mutated after that the `FlagPoleContext` was never updated.

This PR directly references the `StreamManager` in the `FlagPoleContext` and pulls the list of sources live from that whenever needed.