### PR TITLE
ci: refresh runner matrices for the current macos-26 image

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ "26.1" ]
+        xcode: [ "26.2", "26.3", "26.4" ]
         os: [ macos-26 ]
     runs-on: ${{ matrix.os }}
 
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -o pipefail && \
           NSUnbufferedIO=YES \
-          xcrun xcodebuild build -workspace . -scheme Vexil -skipMacroValidation -destination "platform=iOS Simulator,name=iPhone 16e" \
+          xcrun xcodebuild build -workspace . -scheme Vexil -skipMacroValidation -destination "platform=iOS Simulator,name=iPhone 17" \
           | xcbeautify --renderer github-actions
 
   build-ios:

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: [ "swift:6.1", "swift:6.2" ]
+        swift: [ "swift:6.1", "swift:6.2", "swift:6.3" ]
         os: [ amazonlinux2, jammy, rhel-ubi9, noble ]
 
     container:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ "26.1" ]
+        xcode: [ "26.2", "26.3", "26.4" ]
         os: [ macos-26 ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tvos-tests.yml
+++ b/.github/workflows/tvos-tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ "26.1" ]
+        xcode: [ "26.2", "26.3", "26.4" ]
         os: [ macos-26 ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/visionos-tests.yml
+++ b/.github/workflows/visionos-tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ "26.1" ]
+        xcode: [ "26.2", "26.3", "26.4" ]
         os: [ macos-26 ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/watchos-tests.yml
+++ b/.github/workflows/watchos-tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ "26.1" ]
+        xcode: [ "26.2", "26.3", "26.4" ]
         os: [ macos-26 ]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary

GitHub refreshed the `macos-26-arm64` runner image and our CI broke. Two distinct things changed:

1. **`Xcode_26.1.app` no longer exists** on the runner. The image now ships `26.0.1`, `26.1.1`, `26.2` (default), `26.3`, and `26.4`. Every Apple-platform workflow pinned `xcode: ["26.1"]`, so `DEVELOPER_DIR=/Applications/Xcode_26.1.app/Contents/Developer` pointed at a missing path.
2. **`iPhone 16e` is no longer in the iOS 26.4 simulator runtime** (only iPhone 17 / 17 Pro / 17 Pro Max / 17e / iPhone Air on 26.4). With no OS pinned in the destination, `xcodebuild` resolved `name=iPhone 16e` against `OS:latest` (= 26.4) and failed with `Unable to find a device matching the provided destination specifier`. See the failing run: https://github.com/unsignedapps/Vexil/actions/runs/24078536924/job/70404285900

## Changes

- Bump every Apple-platform matrix (`ios`, `macos`, `tvos`, `visionos`, `watchos`) from `["26.1"]` to `["26.2", "26.3", "26.4"]` — gives us coverage across the three most recent Xcode versions on the runner.
- iOS destination: `iPhone 16e` → `iPhone 17` (present in every iOS 26 runtime on the runner, so safe across the matrix).
- tvOS / watchOS / visionOS destinations are unchanged — `Apple TV 4K (3rd generation)`, `Apple Watch Ultra 3 (49mm)`, and the generic visionOS Simulator destination still resolve in 26.2 / 26.3 / 26.4.
- Linux matrix: add `swift:6.3` alongside `6.1` / `6.2` (publicly available now). Expands the Linux matrix from 8 to 12 jobs.

`docs.yml` and `website.yml` (the Xcode 13.0 / 15.4 pins) are intentionally untouched — out of use.

## Test plan

- [ ] iOS Tests matrix passes for 26.2 / 26.3 / 26.4
- [ ] macOS Tests matrix passes for 26.2 / 26.3 / 26.4
- [ ] tvOS Tests matrix passes for 26.2 / 26.3 / 26.4
- [ ] visionOS Tests matrix passes for 26.2 / 26.3 / 26.4
- [ ] watchOS Build Tests matrix passes for 26.2 / 26.3 / 26.4
- [ ] Linux Tests matrix passes including the new `swift:6.3` row across all four base OSes (watch for any unpublished `swift:6.3-<os>` image tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)